### PR TITLE
A median cut builder for Embree

### DIFF
--- a/rtcore/CMakeLists.txt
+++ b/rtcore/CMakeLists.txt
@@ -30,6 +30,7 @@ ADD_LIBRARY(rtcore STATIC
   common/primrefgen.cpp 
   common/heuristic_binning.cpp 
   common/heuristic_spatial.cpp 
+  common/heuristic_median.cpp 
   common/splitter.cpp 
   common/splitter_parallel.cpp 
   common/splitter_fallback.cpp 

--- a/rtcore/common/accel.cpp
+++ b/rtcore/common/accel.cpp
@@ -160,6 +160,35 @@ namespace embree
       }
     }
 
+    /* BVH2 with median cut builder */
+    if (accelTy == "bvh2.mediancut") 
+    {
+      if (triTy == "default")
+#ifdef __AVX__
+        return build<BVH2Builder<HeuristicMedian<Triangle8::logBlockSize> > >(Triangle8::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+#else
+        return build<BVH2Builder<HeuristicMedian<Triangle4::logBlockSize> > >(Triangle4::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+#endif
+      else if (triTy == "triangle1i")
+        return build<BVH2Builder<HeuristicMedian<Triangle1i::logBlockSize> > >(Triangle1i::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else if (triTy == "triangle4i")
+        return build<BVH2Builder<HeuristicMedian<Triangle4i::logBlockSize> > >(Triangle4i::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else if (triTy == "triangle1v")
+        return build<BVH2Builder<HeuristicMedian<Triangle1v::logBlockSize> > >(Triangle1v::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else if (triTy == "triangle4v")
+        return build<BVH2Builder<HeuristicMedian<Triangle4v::logBlockSize> > >(Triangle4v::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else if (triTy == "triangle1")
+        return build<BVH2Builder<HeuristicMedian<Triangle1::logBlockSize> > >(Triangle1::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else if (triTy == "triangle4")
+        return build<BVH2Builder<HeuristicMedian<Triangle4::logBlockSize> > >(Triangle4::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else if (triTy == "triangle8")
+        return build<BVH2Builder<HeuristicMedian<Triangle8::logBlockSize> > >(Triangle8::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else {
+        throw std::runtime_error("invalid triangle type for bvh2: "+std::string(triTy));
+        return null;
+      }
+    }
+
     /* BVH2 with spatial split builder */
     if (accelTy == "bvh2.spatialsplit") 
     {
@@ -212,6 +241,35 @@ namespace embree
         return build<BVH4Builder<HeuristicBinning<Triangle4::logBlockSize> > >(Triangle4::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
       else if (triTy == "triangle8")
          return build<BVH4Builder<HeuristicBinning<Triangle8::logBlockSize> > >(Triangle8::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else {
+        throw std::runtime_error("invalid triangle type for bvh4: "+std::string(triTy));
+        return null;
+      }
+    }
+
+    /* BVH4 with median cut builder */
+    if (accelTy == "bvh4.mediancut") 
+    {
+      if (triTy == "default")
+#ifdef __AVX__
+        return build<BVH4Builder<HeuristicMedian<Triangle8::logBlockSize> > >(Triangle8::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+#else
+        return build<BVH4Builder<HeuristicMedian<Triangle4::logBlockSize> > >(Triangle4::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+#endif
+      else if (triTy == "triangle1i")
+        return build<BVH4Builder<HeuristicMedian<Triangle1i::logBlockSize> > >(Triangle1i::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else if (triTy == "triangle4i")
+        return build<BVH4Builder<HeuristicMedian<Triangle4i::logBlockSize> > >(Triangle4i::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else if (triTy == "triangle1v")
+        return build<BVH4Builder<HeuristicMedian<Triangle1v::logBlockSize> > >(Triangle1v::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else if (triTy == "triangle4v")
+        return build<BVH4Builder<HeuristicMedian<Triangle4v::logBlockSize> > >(Triangle4v::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else if (triTy == "triangle1")
+        return build<BVH4Builder<HeuristicMedian<Triangle1::logBlockSize> > >(Triangle1::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else if (triTy == "triangle4")
+        return build<BVH4Builder<HeuristicMedian<Triangle4::logBlockSize> > >(Triangle4::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
+      else if (triTy == "triangle8")
+         return build<BVH4Builder<HeuristicMedian<Triangle8::logBlockSize> > >(Triangle8::type,intTy,triangles,numTriangles,vertices,numVertices,bounds,freeData);
       else {
         throw std::runtime_error("invalid triangle type for bvh4: "+std::string(triTy));
         return null;

--- a/rtcore/common/heuristic_median.cpp
+++ b/rtcore/common/heuristic_median.cpp
@@ -1,0 +1,149 @@
+// ======================================================================== //
+// Copyright 2009-2012 Intel Corporation                                    //
+//                                                                          //
+// Licensed under the Apache License, Version 2.0 (the "License");          //
+// you may not use this file except in compliance with the License.         //
+// You may obtain a copy of the License at                                  //
+//                                                                          //
+//     http://www.apache.org/licenses/LICENSE-2.0                           //
+//                                                                          //
+// Unless required by applicable law or agreed to in writing, software      //
+// distributed under the License is distributed on an "AS IS" BASIS,        //
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. //
+// See the License for the specific language governing permissions and      //
+// limitations under the License.                                           //
+// ======================================================================== //
+
+#include "heuristic_median.h"
+
+namespace embree
+{
+  template<int logBlockSize>
+  const size_t HeuristicMedian<logBlockSize>::maxBins;
+
+  template<int logBlockSize>
+  void HeuristicMedian<logBlockSize>::bin(const PrimRef* prims, size_t num)
+  {
+    if (num == 0) return;
+    
+    size_t i; for (i=0; i<num-1; i+=2)
+    {
+      /*! map even and odd primitive to bin */
+      const BBox3f prim0 = prims[i+0].bounds(); const Vec3i bin0 = mapping.bin(prim0); const Vec3f center0 = Vec3f(center2(prim0));
+      const BBox3f prim1 = prims[i+1].bounds(); const Vec3i bin1 = mapping.bin(prim1); const Vec3f center1 = Vec3f(center2(prim1));
+      
+      /*! increase bounds for bins for even primitive */
+      const int b00 = bin0.x; counts[b00][0]++; geomBounds[b00][0].grow(prim0); centBounds[b00][0].grow(center0);
+      const int b01 = bin0.y; counts[b01][1]++; geomBounds[b01][1].grow(prim0); centBounds[b01][1].grow(center0);
+      const int b02 = bin0.z; counts[b02][2]++; geomBounds[b02][2].grow(prim0); centBounds[b02][2].grow(center0);
+      
+      /*! increase bounds of bins for odd primitive */
+      const int b10 = bin1.x; counts[b10][0]++; geomBounds[b10][0].grow(prim1); centBounds[b10][0].grow(center1);
+      const int b11 = bin1.y; counts[b11][1]++; geomBounds[b11][1].grow(prim1); centBounds[b11][1].grow(center1);
+      const int b12 = bin1.z; counts[b12][2]++; geomBounds[b12][2].grow(prim1); centBounds[b12][2].grow(center1);
+    }
+    
+    /*! for uneven number of primitives */
+    if (i < num)
+    {
+      /*! map primitive to bin */
+      const BBox3f prim0 = prims[i].bounds(); const Vec3i bin0 = mapping.bin(prim0); const Vec3f center0 = Vec3f(center2(prim0));
+      
+      /*! increase bounds of bins */
+      const int b00 = bin0.x; counts[b00][0]++; geomBounds[b00][0].grow(prim0); centBounds[b00][0].grow(center0);
+      const int b01 = bin0.y; counts[b01][1]++; geomBounds[b01][1].grow(prim0); centBounds[b01][1].grow(center0);
+      const int b02 = bin0.z; counts[b02][2]++; geomBounds[b02][2].grow(prim0); centBounds[b02][2].grow(center0);
+    }
+  }
+  
+  template<int logBlockSize>
+  void HeuristicMedian<logBlockSize>::best(Split& split)
+  {
+    ssef rAreas [maxBins];      //!< area of bounds of primitives on the right
+    ssef rCounts[maxBins];      //!< blocks of primitives on the right
+    
+    /* sweep from right to left and compute parallel prefix of merged bounds */
+    assert(mapping.size() > 0);
+    ssei count = 0; BBox3f bx = empty; BBox3f by = empty; BBox3f bz = empty;
+    for (size_t i=mapping.size()-1; i>0; i--)
+    {
+      count += counts[i];
+      rCounts[i] = ssef(blocks(count));
+      bx = merge(bx,geomBounds[i][0]); rAreas[i][0] = halfArea(bx);
+      by = merge(by,geomBounds[i][1]); rAreas[i][1] = halfArea(by);
+      bz = merge(bz,geomBounds[i][2]); rAreas[i][2] = halfArea(bz);
+    }
+    
+    /* sweep from left to right and compute SAH */
+    ssei ii = 1; ssef bestSAH = pos_inf; ssei bestPos = 0;
+    count = 0; bx = empty; by = empty; bz = empty;
+    for (size_t i=1; i<mapping.size(); i++, ii+=1)
+    {
+      count += counts[i-1];
+      bx = merge(bx,geomBounds[i-1][0]); float Ax = halfArea(bx);
+      by = merge(by,geomBounds[i-1][1]); float Ay = halfArea(by);
+      bz = merge(bz,geomBounds[i-1][2]); float Az = halfArea(bz);
+      const ssef lCount = ssef(blocks(count));
+      const ssef lArea = ssef(Ax,Ay,Az,Az);
+      const ssef sah = lArea*lCount + rAreas[i]*rCounts[i];
+      bestPos = select(sah < bestSAH,ii ,bestPos);
+      bestSAH = select(sah < bestSAH,sah,bestSAH);
+    }
+
+    /* find best dimension */
+    for (int i=0; i<3; i++) 
+    {
+      if (unlikely(pinfo.centBounds.lower[i] >= pinfo.centBounds.upper[i])) 
+        continue;
+      
+      if (bestSAH[i] < split.cost && bestPos[i] != 0) {
+        split.dim = i;
+        split.pos = bestPos[i];
+        split.cost = bestSAH[i];
+      }
+    }
+    split.mapping = mapping;
+    if (split.pos == 0) return;
+    
+    /* calculate geometry info from binning data */
+    size_t pos = split.pos, dim = split.dim;
+    size_t numLeft = 0, numRight = 0;
+    BBox3f lcentBounds = empty, rcentBounds = empty;
+    BBox3f lgeomBounds = empty, rgeomBounds = empty;
+    for (size_t i=0; i<pos; i++) {
+      numLeft += counts[i][dim];
+      lcentBounds.grow(centBounds[i][dim]);
+      lgeomBounds.grow(geomBounds[i][dim]);
+    }
+    for (size_t i=pos; i<mapping.size(); i++) {
+      numRight += counts[i][dim];
+      rcentBounds.grow(centBounds[i][dim]);
+      rgeomBounds.grow(geomBounds[i][dim]);
+    }
+    assert(numLeft + numRight == pinfo.size());
+    new (&split.linfo) PrimInfo(numLeft ,lgeomBounds,lcentBounds);
+    new (&split.rinfo) PrimInfo(numRight,rgeomBounds,rcentBounds);
+  }
+  
+  template<int logBlockSize>
+  void HeuristicMedian<logBlockSize>::reduce(const HeuristicMedian binners[], size_t num, HeuristicMedian& binner_o)
+  {
+    binner_o = binners[0];
+    for (size_t tid=1; tid<num; tid++) {
+      const HeuristicMedian& binner = binners[tid];
+      for (size_t bin=0; bin<binner.mapping.size(); bin++) 
+      {
+        for (size_t dim=0; dim<3; dim++) {
+          binner_o.counts    [bin][dim] += binner.counts[bin][dim];
+          binner_o.geomBounds[bin][dim].grow(binner.geomBounds[bin][dim]);
+          binner_o.centBounds[bin][dim].grow(binner.centBounds[bin][dim]);
+        }
+      }
+    }
+  }
+  
+  /*! explicit template instantiations */
+  template class HeuristicMedian<0>;
+  template class HeuristicMedian<2>;
+  template class HeuristicMedian<3>;
+}

--- a/rtcore/common/heuristic_median.h
+++ b/rtcore/common/heuristic_median.h
@@ -1,0 +1,203 @@
+// ======================================================================== //
+// Copyright 2009-2012 Intel Corporation                                    //
+//                                                                          //
+// Licensed under the Apache License, Version 2.0 (the "License");          //
+// you may not use this file except in compliance with the License.         //
+// You may obtain a copy of the License at                                  //
+//                                                                          //
+//     http://www.apache.org/licenses/LICENSE-2.0                           //
+//                                                                          //
+// Unless required by applicable law or agreed to in writing, software      //
+// distributed under the License is distributed on an "AS IS" BASIS,        //
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. //
+// See the License for the specific language governing permissions and      //
+// limitations under the License.                                           //
+// ======================================================================== //
+
+#ifndef __EMBREE_HEURISTIC_MEDIAN_H__
+#define __EMBREE_HEURISTIC_MEDIAN_H__
+
+#include "accel.h"
+#include "primref.h"
+
+namespace embree
+{
+  /* Median cut heuristic. Finds the split with the best SAH
+   * heuristic at the middle of the interval range by testing 
+   * for all 3 dimensions. This is nothing more than an object 
+   * binning heuristic with only 2 bins. */
+  
+  template<int logBlockSize>
+    class HeuristicMedian
+  {
+    /*! Maximal number of bins. */
+    static const size_t maxBins = 2; 
+
+  public:
+
+    /*! We build the tree depth first */
+    static const bool depthFirst = true;
+    
+    /*! stores bounding information for a set of primitives */
+    class PrimInfo
+    {
+    public:
+      __forceinline PrimInfo () 
+        : num(0), geomBounds(empty), centBounds(empty) {}
+
+      __forceinline PrimInfo (size_t num, const BBox3f& geomBounds) 
+        : num(num), geomBounds(geomBounds), centBounds(geomBounds) {}
+      
+      __forceinline PrimInfo (size_t num, const BBox3f& geomBounds, const BBox3f& centBounds) 
+        : num(num), geomBounds(geomBounds), centBounds(centBounds) {}
+      
+      /*! returns the number of primitives */
+      __forceinline size_t size() const { 
+        return num; 
+      }
+
+      /*! return the surface area heuristic when creating a leaf */
+      __forceinline float sah () const { 
+        return halfArea(geomBounds)*blocks(num); 
+      }
+
+      /*! clears global data */
+      __forceinline void clear () { 
+      }
+      
+      /*! stream output */
+      friend std::ostream& operator<<(std::ostream& cout, const PrimInfo& pinfo) {
+        return cout << "PrimInfo { num = " << pinfo.num << ", geomBounds = " << pinfo.geomBounds << ", centBounds = " << pinfo.centBounds << "}";
+      }
+      
+    public:
+      size_t num;          //!< number of primitives
+      BBox3f geomBounds;   //!< geometry bounds of primitives
+      BBox3f centBounds;   //!< centroid bounds of primitives
+    };
+        
+    /*! mapping from bounding boxes to bins */
+    class Mapping
+    {
+    public:
+      
+      /*! default constructor */
+      __forceinline Mapping () {}
+      
+      /*! construct from primitive info */
+      __forceinline Mapping (const PrimInfo& pinfo)
+      {
+        ofs   = pinfo.centBounds.lower;
+        scale = rcp(pinfo.centBounds.upper - pinfo.centBounds.lower) * Vec3f(float(maxBins));
+      }
+      
+      /*! returns number of bins */
+      __forceinline size_t size() const { return maxBins; }
+      
+      /*! Computes the bin numbers for each dimension for a box. */
+      __forceinline Vec3i bin_unsafe(const BBox3f& box) const {
+        return Vec3i((center2(box) - ofs)*scale-Vec3f(0.5f));
+      }
+      
+      /*! Computes the bin numbers for each dimension for a box. */
+      __forceinline Vec3i bin(const BBox3f& box) const {
+        return clamp(bin_unsafe(box),Vec3i(0),Vec3i(int(maxBins-1)));
+      }
+      
+    private:
+      Vec3f ofs;        //!< offset to compute bin
+      Vec3f scale;      //!< scaling factor to compute bin
+    };
+    
+    /*! Stores information about an object split. */
+    class Split
+    {
+    public:
+      
+      /*! create an invalid split by default */
+      __forceinline Split () : dim(0), pos(0), cost(inf) {}
+      
+      /*! return SAH cost of performing the split */
+      __forceinline float sah() const { return cost; } 
+      
+      /*! return true if this is a spatial split */
+      __forceinline bool spatial() const { return false; }
+
+      /*! tests if a primitive belongs to the left side of the split */
+      __forceinline int left(const PrimRef& prim) const {
+        return mapping.bin_unsafe(prim.bounds())[dim] < pos;
+      }
+
+      /*! splitting of the primitive if required */
+      __forceinline void split(const PrimRef& prim, PrimRef& lprim_o, PrimRef& rprim_o) const {
+        new (&lprim_o) PrimRef(empty,size_t(-1));
+        new (&rprim_o) PrimRef(empty,size_t(-1));
+        assert(false);
+      }
+      
+      /*! stream output */
+      friend std::ostream& operator<<(std::ostream& cout, const Split& split) {
+        return cout << "Split { dim = " << split.dim << 
+          ", pos = " << split.pos << 
+          ", sah = " << split.cost << 
+          ", linfo = " << split.linfo <<
+          ", rinfo = " << split.rinfo << "}";
+      }
+      
+    public:
+      Mapping mapping;    //!< Mapping to bins
+      int dim;            //!< Best object split dimension
+      int pos;            //!< Best object split position
+      float cost;         //!< SAH cost of performing best object split
+      
+    public:
+      PrimInfo linfo;     //!< Left geometry information
+      PrimInfo rinfo;     //!< Right geometry information
+    };
+    
+    /*! default constructor */
+    __forceinline HeuristicMedian () {}
+    
+    /*! construction from geometry info */
+    __forceinline HeuristicMedian (const PrimInfo& pinfo, const BuildTriangle* triangles, const Vec3fa* vertices)
+      : pinfo(pinfo), mapping(pinfo) { clear(); }
+    
+    /*! clear the binner */
+    __forceinline void clear() 
+    {
+      for (size_t i=0; i<mapping.size(); i++) {
+        counts[i] = 0;
+        geomBounds[i][0] = geomBounds[i][1] = geomBounds[i][2] = empty;
+        centBounds[i][0] = centBounds[i][1] = centBounds[i][2] = empty;
+      }
+    }
+    
+    /*! bin an array of primitives */
+    void bin(const PrimRef* prim, size_t num);
+    
+    /*! merge multiple binning infos into one */
+    static void reduce(const HeuristicMedian binners[], size_t num, HeuristicMedian& binner_o);
+    
+    /*! calculate the best possible split */
+    void best(Split& split_o);
+  
+  private:
+    
+    /*! Compute the number of blocks occupied for each dimension. */
+    __forceinline static ssei blocks(const ssei& a) { return (a+ssei((1 << logBlockSize)-1)) >> logBlockSize; }
+    
+    /*! Compute the number of blocks occupied in one dimension. */
+    __forceinline static int  blocks(size_t a) { return (int)((a+((1LL << logBlockSize)-1)) >> logBlockSize); }
+  
+  public:
+    PrimInfo pinfo;                //!< bounding information of geometry
+    Mapping mapping;               //!< mapping from geometry to the bins
+    
+    /* initialize binning counter and bounds */
+    ssei   counts    [maxBins];    //< number of primitives mapped to bin
+    BBox3f geomBounds[maxBins][4]; //< bounds for every bin in every dimension
+    BBox3f centBounds[maxBins][4]; //< centroid bounds for every bin in every dimension
+  };
+}
+
+#endif

--- a/rtcore/common/heuristics.h
+++ b/rtcore/common/heuristics.h
@@ -21,12 +21,16 @@
 #include "primrefblock.h"
 
 #include "heuristic_binning.h"
+#include "heuristic_median.h"
 #include "heuristic_spatial.h"
 
 #define INSTANTIATE_TEMPLATE_BY_HEURISTIC(Base)         \
   template class Base<HeuristicBinning<0> >;            \
   template class Base<HeuristicBinning<2> >;         \
   template class Base<HeuristicBinning<3> >;         \
+  template class Base<HeuristicMedian<0> >;            \
+  template class Base<HeuristicMedian<2> >;         \
+  template class Base<HeuristicMedian<3> >;         \
   template class Base<HeuristicSpatial<0> >;         \
   template class Base<HeuristicSpatial<2> >;         \
   template class Base<HeuristicSpatial<3> >;
@@ -35,6 +39,9 @@
   template class Splitter<HeuristicBinning<0>, atomic_set<PrimRefBlock> >; \
   template class Splitter<HeuristicBinning<2>, atomic_set<PrimRefBlock> >; \
   template class Splitter<HeuristicBinning<3>, atomic_set<PrimRefBlock> >; \
+  template class Splitter<HeuristicMedian<0>, atomic_set<PrimRefBlock> >; \
+  template class Splitter<HeuristicMedian<2>, atomic_set<PrimRefBlock> >; \
+  template class Splitter<HeuristicMedian<3>, atomic_set<PrimRefBlock> >; \
   template class Splitter<HeuristicSpatial<0>, atomic_set<PrimRefBlock> >; \
   template class Splitter<HeuristicSpatial<2>, atomic_set<PrimRefBlock> >; \
   template class Splitter<HeuristicSpatial<3>, atomic_set<PrimRefBlock> >;

--- a/rtcore/rtcore.vcxproj
+++ b/rtcore/rtcore.vcxproj
@@ -218,6 +218,7 @@
     <ClCompile Include="common\accel.cpp" />
     <ClCompile Include="common\alloc.cpp" />
     <ClCompile Include="common\heuristic_binning.cpp" />
+    <ClCompile Include="common\heuristic_median.cpp" />
     <ClCompile Include="common\heuristic_spatial.cpp" />
     <ClCompile Include="common\primrefgen.cpp" />
     <ClCompile Include="common\splitter.cpp" />
@@ -242,6 +243,7 @@
     <ClInclude Include="common\default.h" />
     <ClInclude Include="common\heuristics.h" />
     <ClInclude Include="common\heuristic_binning.h" />
+    <ClInclude Include="common\heuristic_median.h" />
     <ClInclude Include="common\heuristic_spatial.h" />
     <ClInclude Include="common\hit.h" />
     <ClInclude Include="common\intersector.h" />


### PR DESCRIPTION
Just for the sake of comparison, I have implemented a median cut builder. Not surprisingly, it has the fastest build times and the slowest rendering performance, although the gap with object splitting is narrower than I expected. 

To use this builder, specify -accel [bvh2, bvh4, bvh4mb].mediancut on the command line.

A note on the implementation: once you realize that a median cut is a special case of object spllitting with only two bins at all levels, coding the algorithm is really straightforward within Embree framework. Of course, the resulting implementation could have been made even simpler for improved build times but I was more interested into rendering performance comparisons.
