### PR TITLE
Color4 constructor from Col3c, set alpha to 1.

### DIFF
--- a/common/math/color.h
+++ b/common/math/color.h
@@ -45,7 +45,7 @@ namespace embree
     __forceinline explicit Color4 (const float v) : m128(_mm_set1_ps(v)) {}
     __forceinline          Color4 (const float r, const float g, const float b, const float a) : m128(_mm_set_ps(a,b,g,r)) {}
 
-    __forceinline explicit Color4 ( const Col3c& other ) { m128 = _mm_mul_ps(_mm_set_ps(1.0f,other.b,other.g,other.r),_mm_set1_ps(one_over_255)); }
+    __forceinline explicit Color4 ( const Col3c& other ) { m128 = _mm_mul_ps(_mm_set_ps(255.0f,other.b,other.g,other.r),_mm_set1_ps(one_over_255)); }
     __forceinline explicit Color4 ( const Col3f& other ) { m128 = _mm_set_ps(1.0f,other.b,other.g,other.r); }
     __forceinline explicit Color4 ( const Col4c& other ) { m128 = _mm_mul_ps(_mm_set_ps(other.a,other.b,other.g,other.r),_mm_set1_ps(one_over_255)); }
     __forceinline explicit Color4 ( const Col4f& other ) { m128 = _mm_set_ps(other.a,other.b,other.g,other.r); }


### PR DESCRIPTION
Color4 constructor from Col3c initialized the fourth component to 1/255.
This is unintuitive and inconsistent with the overloaded constructor
from Col3f, which initializes the fourth component to 1.0.
