### PR TITLE
added a way to query user defined pointer data on geometry to the API.

### DIFF
--- a/include/embree2/rtcore_geometry.h
+++ b/include/embree2/rtcore_geometry.h
@@ -245,6 +245,14 @@ RTCORE_API void rtcSetOcclusionFilterFunction8 (RTCScene scene, unsigned geomID,
 /*! \brief Sets the occlusion filter function for ray packets of size 16. */
 RTCORE_API void rtcSetOcclusionFilterFunction16 (RTCScene scene, unsigned geomID, RTCFilterFunc16 func);
 
+/*! Set pointer for user defined data per geometry. Invokations
+ *  of the various user intersect and occluded functions get passed
+ *  this data pointer when called. */
+RTCORE_API void rtcSetUserData (RTCScene scene, unsigned geomID, void* ptr);
+
+/*! Get pointer for user defined data per geometry based on geomID. */
+RTCORE_API void* rtcGetUserData (RTCScene scene, unsigned geomID);
+
 /*! \brief Deletes the geometry. */
 RTCORE_API void rtcDeleteGeometry (RTCScene scene, unsigned geomID);
 

--- a/include/embree2/rtcore_geometry.isph
+++ b/include/embree2/rtcore_geometry.isph
@@ -187,6 +187,14 @@ void rtcSetOcclusionFilterFunction1 (RTCScene scene, uniform unsigned int geomID
 /*! \brief Sets the occlusion filter function for varying rays. */
 void rtcSetOcclusionFilterFunction (RTCScene scene, uniform unsigned int geomID, uniform RTCFilterFuncVarying func);
 
+/*! Set pointer for user defined data per geometry. Invokations
+ *  of the various user intersect and occluded functions get passed
+ *  this data pointer when called. */
+void rtcSetUserData (RTCScene scene, uniform unsigned int geomID, void* uniform ptr);
+
+/*! Get pointer for user defined data per geometry based on geomID. */
+void* uniform rtcGetUserData (RTCScene scene, uniform unsigned int geomID);
+
 /*! \brief Deletes the geometry. */
 void rtcDeleteGeometry (RTCScene scene, uniform unsigned int geomID);
 

--- a/include/embree2/rtcore_geometry_user.h
+++ b/include/embree2/rtcore_geometry_user.h
@@ -87,11 +87,6 @@ typedef void (*RTCOccludedFunc16) (const void* valid, /*! pointer to valid mask 
 RTCORE_API unsigned rtcNewUserGeometry (RTCScene scene,        /*!< the scene the user geometry set is created in */
                                         size_t numGeometries   /*!< the number of geometries contained in the set */);
 
-/*! Set data pointer for intersect and occluded functions. Invokations
- *  of the various user intersect and occluded functions get passed
- *  this data pointer when called. */
-RTCORE_API void rtcSetUserData (RTCScene scene, unsigned geomID, void* ptr);
-
 /*! Sets the bounding function to calculate bounding boxes of the user
  *  geometry items when building spatial index structures. The
  *  calculated bounding box have to be conservative and should be

--- a/include/embree2/rtcore_geometry_user.isph
+++ b/include/embree2/rtcore_geometry_user.isph
@@ -84,11 +84,6 @@ typedef void (*RTCDisplacementFunc)(void* uniform ptr,               /*!< pointe
 uniform unsigned int rtcNewUserGeometry (RTCScene scene,                  /*!< the scene the user geometry set is created in */
                                          uniform size_t numGeometries     /*!< the number of geometries contained in the set */);
 
-/*! Set data pointer for intersect and occluded functions. Invokations
- *  of the various user intersect and occluded functions get passed
- *  this data pointer when called. */
-void rtcSetUserData (RTCScene scene, uniform unsigned int geomID, void* uniform ptr);
-
 /*! Sets the bounding function to calculate bounding boxes of the user
  *  geometry items when building spatial index structures. The
  *  calculated bounding box have to be conservative and should be

--- a/kernels/common/geometry.h
+++ b/kernels/common/geometry.h
@@ -167,9 +167,15 @@ namespace embree
     /*! user geometry only */
   public:
 
-    /*! Set user data for intersect and occluded functions. */
+    /*! Set user data pointer, which is also used for intersect and occluded functions. */
     virtual void setUserData (void* ptr, bool ispc = false) { 
       process_error(RTC_INVALID_OPERATION,"operation not supported for this geometry"); 
+    }
+
+    /*! Get user data pointer. */
+    virtual void* getUserData (bool ispc = false) {
+      process_error(RTC_INVALID_OPERATION,"operation not supported for this geometry");
+      return 0;
     }
 
     /*! Set bounds function. */

--- a/kernels/common/rtcore.cpp
+++ b/kernels/common/rtcore.cpp
@@ -938,6 +938,19 @@ namespace embree
     CATCH_END;
   }
 
+  RTCORE_API void* rtcGetUserData (RTCScene scene, unsigned geomID)
+  {
+    void* userData = NULL;
+    CATCH_BEGIN;
+    TRACE(rtcGetUserData);
+    VERIFY_HANDLE(scene);
+    VERIFY_GEOMID(geomID);
+    // read only, not locked for performance
+    userData = ((Scene*)scene)->get(geomID)->getUserData();
+    CATCH_END;
+    return userData;
+  }
+
   RTCORE_API void rtcSetBoundsFunction (RTCScene scene, unsigned geomID, RTCBoundsFunc bounds)
   {
     CATCH_BEGIN;

--- a/kernels/common/rtcore_ispc.cpp
+++ b/kernels/common/rtcore_ispc.cpp
@@ -174,7 +174,19 @@ namespace embree
     ((Scene*)scene)->get(geomID)->setUserData(ptr,true);
     CATCH_END;
   }
-  
+
+  extern "C" void* ispcGetUserData (RTCScene scene, unsigned geomID)
+  {
+    void* userData = NULL;
+    CATCH_BEGIN;
+    TRACE(rtcSetUserData);
+    VERIFY_HANDLE(scene);
+    VERIFY_GEOMID(geomID);
+    userData = ((Scene*)scene)->get(geomID)->getUserData(true);
+    CATCH_END;
+    return userData;
+  }
+
   extern "C" void ispcSetBoundsFunction (RTCScene scene, unsigned geomID, RTCBoundsFunc bounds) {
     rtcSetBoundsFunction(scene,geomID,bounds);
   }

--- a/kernels/common/rtcore_ispc.ispc
+++ b/kernels/common/rtcore_ispc.ispc
@@ -70,6 +70,7 @@ extern "C" void ispcDeleteGeometry (RTCScene scene, uniform unsigned int geomID)
 
 extern "C" void ispcSetBoundsFunction (RTCScene scene, uniform unsigned int geomID, void* uniform bounds);
 extern "C" void ispcSetUserData (RTCScene scene, uniform unsigned int geomID, void* uniform ptr);
+extern "C" void* uniform ispcGetUserData (RTCScene scene, uniform unsigned int geomID);
 
 extern "C" void ispcSetIntersectFunction1 (RTCScene scene, uniform unsigned int geomID, void* uniform intersect);
 extern "C" void ispcSetIntersectFunction4 (RTCScene scene, uniform unsigned int geomID, void* uniform intersect); 
@@ -254,6 +255,10 @@ void rtcDeleteGeometry (RTCScene scene, uniform unsigned int geomID) {
 
 void rtcSetUserData (RTCScene scene, uniform unsigned int geomID, void* uniform ptr) {
   ispcSetUserData(scene,geomID,ptr);
+}
+
+void* uniform rtcGetUserData (RTCScene scene, uniform unsigned int geomID) {
+  return ispcGetUserData(scene,geomID);
 }
 
 void rtcSetBoundsFunction (RTCScene scene, uniform unsigned int geomID, uniform RTCBoundsFunc bounds) {

--- a/kernels/common/scene_bezier_curves.cpp
+++ b/kernels/common/scene_bezier_curves.cpp
@@ -124,6 +124,10 @@ namespace embree
     userPtr = ptr;
   }
 
+  void* BezierCurves::getUserData(bool ispc) {
+    return userPtr;
+  }
+
   void BezierCurves::immutable () 
   {
     bool freeCurves    = true; //!parent->needCurves;

--- a/kernels/common/scene_bezier_curves.h
+++ b/kernels/common/scene_bezier_curves.h
@@ -44,6 +44,7 @@ namespace embree
       void* map(RTCBufferType type);
       void unmap(RTCBufferType type);
       void setUserData (void* ptr, bool ispc);
+      void* getUserData(bool ispc);
       void immutable ();
       bool verify ();
 

--- a/kernels/common/scene_subdiv_mesh.cpp
+++ b/kernels/common/scene_subdiv_mesh.cpp
@@ -174,6 +174,10 @@ namespace embree
     userPtr = ptr;
   }
 
+  void* SubdivMesh::getUserData(bool ispc) {
+    return userPtr;
+  }
+
   void SubdivMesh::setDisplacementFunction (RTCDisplacementFunc func, RTCBounds* bounds) 
   {
     if (parent->isStatic() && parent->isBuild()) {

--- a/kernels/common/scene_subdiv_mesh.h
+++ b/kernels/common/scene_subdiv_mesh.h
@@ -274,6 +274,7 @@ namespace embree
     void* map(RTCBufferType type);
     void unmap(RTCBufferType type);
     void setUserData (void* ptr, bool ispc);
+    void* getUserData(bool ispc);
     void immutable ();
     bool verify ();
     void setDisplacementFunction (RTCDisplacementFunc func, RTCBounds* bounds);

--- a/kernels/common/scene_triangle_mesh.cpp
+++ b/kernels/common/scene_triangle_mesh.cpp
@@ -133,6 +133,10 @@ namespace embree
     userPtr = ptr;
   }
 
+  void* TriangleMesh::getUserData(bool ispc) {
+    return userPtr;
+  }
+
   void TriangleMesh::immutable () 
   {
     bool freeTriangles = !parent->needTriangles;

--- a/kernels/common/scene_triangle_mesh.h
+++ b/kernels/common/scene_triangle_mesh.h
@@ -44,6 +44,7 @@ namespace embree
     void* map(RTCBufferType type);
     void unmap(RTCBufferType type);
     void setUserData (void* ptr, bool ispc);
+    void* getUserData(bool ispc);
     void immutable ();
     bool verify ();
 

--- a/kernels/common/scene_user_geometry.cpp
+++ b/kernels/common/scene_user_geometry.cpp
@@ -38,7 +38,11 @@ namespace embree
   void UserGeometry::setUserData (void* ptr, bool ispc) {
     intersectors.ptr = ptr;
   }
-  
+
+  void* UserGeometry::getUserData(bool ispc) {
+    return intersectors.ptr;
+  }
+
   void UserGeometry::setBoundsFunction (RTCBoundsFunc bounds) {
     this->boundsFunc = bounds;
   }

--- a/kernels/common/scene_user_geometry.h
+++ b/kernels/common/scene_user_geometry.h
@@ -51,6 +51,7 @@ namespace embree
   public:
     UserGeometry (Scene* parent, size_t items); 
     virtual void setUserData (void* ptr, bool ispc);
+    virtual void* getUserData(bool ispc);
     virtual void setBoundsFunction (RTCBoundsFunc bounds);
     virtual void setIntersectFunction (RTCIntersectFunc intersect, bool ispc);
     virtual void setIntersectFunction4 (RTCIntersectFunc4 intersect4, bool ispc);


### PR DESCRIPTION
This will be useful in general to allow the renderer client to attach and query an arbitrary user data pointer defined for a geometry. Because the usage is beyond the user defined geometry, I have moved the interface to rtcore_geometry.h.

@svenwoop, @cbenthin