### PR TITLE
Fixed the embree::g_device name collision in verify.cpp and retrace.c…

### DIFF
--- a/tests/retrace.cpp
+++ b/tests/retrace.cpp
@@ -50,7 +50,7 @@
 
 namespace embree
 {
-  RTCDevice g_device = nullptr;
+  static RTCDevice g_device = nullptr;
 
   struct RayStreamStats
   {

--- a/tests/verify.cpp
+++ b/tests/verify.cpp
@@ -75,7 +75,7 @@ namespace embree
     return (cpu_features & isa) == isa;
   }
 
-  RTCDevice g_device = nullptr;
+  static RTCDevice g_device = nullptr;
 
 #if !defined(__MIC__)
   RTCAlgorithmFlags aflags = (RTCAlgorithmFlags) (RTC_INTERSECT1 


### PR DESCRIPTION
I'm experiencing a name collision with embree::g_device variable declared in verify.cpp and retrace.cpp and the one used internally by Embree library. This happen when compiling a static version of the library (ENABLE_STATIC_LIB=ON) on my Linux box.

I have simply to declare static the embree::g_device variable used in verify.cpp/retrace.cpp in order to avoid the problem.