### PR TITLE
fix syntax, link issues in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,17 @@ transparently transitioning to 2MB pages.
 Embree is optimized for Intel CPUs supporting SSE, AVX, AVX2, and
 AVX-512 instructions, and requires at least a CPU with support for
 SSE2.
+
 Contributing to Embree
 ----------------------
 
 To contribute code to the Embree repository you need to sign a
 Contributor License Agreement (CLA). Individuals need to fill out the
-[Individual Contributor License Agreement (ICLA)]. Corporations need to
-fill out the [Corporate Contributor License Agreement (CCLA)] and each
-employee that wants to contribute has to fill out an [Individual
-Contributor License Agreement (ICLA)]. Please follow the instructions of
-the CLA forms to send them.
+[Individual Contributor License Agreement (ICLA)](https://embree.github.io/data/Embree-ICLA.pdf).
+Corporations need to fill out the 
+[Corporate Contributor License Agreement (CCLA)](https://embree.github.io/data/Embree-CCLA.pdf) 
+and each employee that wants to contribute has to fill out an ICLA.
+Please follow the instructions of the CLA forms to send them.
 
 Embree Support and Contact
 --------------------------


### PR DESCRIPTION
- fix trivial syntax error at https://github.com/embree/embree#embree-is-optimized-for-intel-cpus-supporting-sse-avx-avx2-andavx-512-instructions-and-requires-at-least-a-cpu-with-support-forsse2contributing-to-embree
- add links for ICLA and CCLA since there appeared to be an intent to add those (because of the brackets)

I work for Intel.