### PR TITLE
Updated Find Embree tutorial to work with Embree 3.2 and newer.

### DIFF
--- a/tutorials/find_embree/CMakeLists.txt
+++ b/tutorials/find_embree/CMakeLists.txt
@@ -15,9 +15,9 @@
 ## ======================================================================== ##
 
 PROJECT(find_embree)
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.2.0)
 
-FIND_PACKAGE(embree 2.0 REQUIRED)
+FIND_PACKAGE(embree 3.0 REQUIRED)
 
 INCLUDE_DIRECTORIES(${EMBREE_INCLUDE_DIRS})
 ADD_EXECUTABLE(find_embree find_embree.cpp)


### PR DESCRIPTION
The "Find Embree" tutorial needs to be updated for Embree 3.