### PR TITLE
move a cray specific setting to the right place

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,10 @@ ELSE()
   ENDIF ()
 ENDIF()
 
+IF(CMAKE_CXX_COMPILER_WRAPPER STREQUAL "CrayPrgEnv")
+  SET(EMBREE_ISA_SSE42 OFF)
+ENDIF()
+
 ##############################################################
 # ISA configuration continued
 ##############################################################

--- a/common/cmake/crayprgenv.cmake
+++ b/common/cmake/crayprgenv.cmake
@@ -20,7 +20,5 @@ SET(FLAGS_AVX2      "-target-cpu=haswell")
 SET(FLAGS_AVX512KNL "-target-cpu=mic-knl")
 SET(FLAGS_AVX512SKX "-target-cpu=x86-skylake")
 
-SET_PROPERTY(CACHE EMBREE_ISA_SSE42 PROPERTY VALUE OFF)
-
 STRING(TOLOWER "${CMAKE_CXX_COMPILER_ID}" _lower_compiler_id)
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/${_lower_compiler_id}.cmake" OPTIONAL)


### PR DESCRIPTION
The code got shifted around such that the attempt to disable
sse42 on cray in the crayprgenv section failed because the cache
variable has not yet been created. This change moves that
specific bit later to make everything work as intended.

Note, there is also a corresponding change needed in ospray because the sense of NONE and DEFAULT changed.