### PR TITLE
Typo in documentation for Cmake option EMBREE_API_NAMESPACE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Version History
 ---------------
 
 ### New Features in Embree 3.5.2
--   Added EMBREE_ISA_NAMESPACE cmake option that allows to put all Embree API functions
+-   Added EMBREE_API_NAMESPACE cmake option that allows to put all Embree API functions
     inside a user defined namespace.
 -   Added EMBREE_LIBRARY_NAME cmake option that allows to rename the Embree library.
 -   When Embree is compiled as static library, EMBREE_STATIC_LIB has no longer to get

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ parameters that can be configured in CMake:
   `embree3_avx512skx.a`). You have to link these libraries in exactly
   this order of increasing ISA.
 
-+ `EMBREE_ISA_NAMESPACE`: Specifies a namespace name to put all Embree
++ `EMBREE_API_NAMESPACE`: Specifies a namespace name to put all Embree
   API symbols inside. By default no namespace is used and plain C symbols
   exported.
 

--- a/doc/src/changelog.md
+++ b/doc/src/changelog.md
@@ -2,7 +2,7 @@ Version History
 ---------------
 
 ### New Features in Embree 3.5.2
--   Added EMBREE_ISA_NAMESPACE cmake option that allows to put all Embree API functions
+-   Added EMBREE_API_NAMESPACE cmake option that allows to put all Embree API functions
     inside a user defined namespace.
 -   Added EMBREE_LIBRARY_NAME cmake option that allows to rename the Embree library.
 -   When Embree is compiled as static library, EMBREE_STATIC_LIB has no longer to get

--- a/doc/src/compilation.md
+++ b/doc/src/compilation.md
@@ -237,7 +237,7 @@ parameters that can be configured in CMake:
   `embree3_avx512skx.a`). You have to link these libraries in exactly
   this order of increasing ISA.
 
-+ `EMBREE_ISA_NAMESPACE`: Specifies a namespace name to put all Embree
++ `EMBREE_API_NAMESPACE`: Specifies a namespace name to put all Embree
   API symbols inside. By default no namespace is used and plain C symbols
   exported.
 


### PR DESCRIPTION
The CMake option EMBREE_API_NAMESPACE works fine for me. The documentation however states it would be called EMBREE_ISA_NAMESPACE (ISA instead of API). This PR just renames the option in the documentation.