### PR TITLE
Doc fix: triangles must be UINT3 not UINT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2384,9 +2384,9 @@ specified by setting an index buffer (`RTC_BUFFER_TYPE_INDEX` type) and
 the triangle vertices by setting a vertex buffer
 (`RTC_BUFFER_TYPE_VERTEX` type). See `rtcSetGeometryBuffer` and
 `rtcSetSharedGeometryBuffer` for more details on how to set buffers.
-The index buffer contains an array of three 32-bit indices per triangle
-(`RTC_FORMAT_UINT` format) and the number of primitives is inferred
-from the size of that buffer. The vertex buffer contains an array of
+The index buffer must contain an array of three 32-bit indices per triangle
+(`RTC_FORMAT_UINT3` format) and the number of primitives is inferred
+from the size of that buffer. The vertex buffer must contain an array of
 single precision `x`, `y`, `z` floating point coordinates
 (`RTC_FORMAT_FLOAT3` format), and the number of vertices are inferred
 from the size of that buffer. The vertex buffer can be at most 16 GB

--- a/man/man3/RTC_GEOMETRY_TYPE_TRIANGLE.3embree3
+++ b/man/man3/RTC_GEOMETRY_TYPE_TRIANGLE.3embree3
@@ -27,10 +27,10 @@ setting a vertex buffer (\f[C]RTC_BUFFER_TYPE_VERTEX\f[] type).
 See \f[C]rtcSetGeometryBuffer\f[] and
 \f[C]rtcSetSharedGeometryBuffer\f[] for more details on how to set
 buffers.
-The index buffer contains an array of three 32\-bit indices per triangle
-(\f[C]RTC_FORMAT_UINT\f[] format) and the number of primitives is
+The index buffer must contain an array of three 32\-bit indices per triangle
+(\f[C]RTC_FORMAT_UINT3\f[] format) and the number of primitives is
 inferred from the size of that buffer.
-The vertex buffer contains an array of single precision \f[C]x\f[],
+The vertex buffer must contain an array of single precision \f[C]x\f[],
 \f[C]y\f[], \f[C]z\f[] floating point coordinates
 (\f[C]RTC_FORMAT_FLOAT3\f[] format), and the number of vertices are
 inferred from the size of that buffer.


### PR DESCRIPTION
This also changes "contains" to "must contain" to make it clear that
clients should not attempt to share a USHORT3 index buffer, which
is a fairly common index format for real-time graphics.