### PR TITLE
Fix mixed up comments in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5463,8 +5463,8 @@ RTCHit
       float u;             // barycentric u coordinate of hit
       float v;             // barycentric v coordinate of hit
 
-      unsigned int primID; // geometry ID
-      unsigned int geomID; // primitive ID
+      unsigned int primID; // primitive ID
+      unsigned int geomID; // geometry ID
       unsigned int instID[RTC_MAX_INSTANCE_LEVEL_COUNT]; // instance ID
     };
 

--- a/doc/src/api/RTCHit.md
+++ b/doc/src/api/RTCHit.md
@@ -17,8 +17,8 @@
       float u;             // barycentric u coordinate of hit
       float v;             // barycentric v coordinate of hit
 
-      unsigned int primID; // geometry ID
-      unsigned int geomID; // primitive ID
+      unsigned int primID; // primitive ID
+      unsigned int geomID; // geometry ID
       unsigned int instID[RTC_MAX_INSTANCE_LEVEL_COUNT]; // instance ID
     };
 


### PR DESCRIPTION
This PR fixes a misprint in the documentation: Two comments describing struct members were mixed up.