### PR TITLE
Updated package list for MacPorts on macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ version of GLUT.
 Under macOS, all these dependencies can be installed
 using [MacPorts](http://www.macports.org/):
 
-    sudo port install cmake tbb-devel glfw-devel
+    sudo port install cmake tbb glfw-devel openimageio
 
 Depending on your Linux distribution you can install these dependencies
 using `yum` or `apt-get`.  Some of these packages might already be


### PR DESCRIPTION
Changed tbb-devel to tbb. See: https://www.macports.org/ports.php?by=name&substr=tbb
Added openimageio to list of packages (https://ports.macports.org/port/openimageio)

BTW: Using [Homebrew](https://brew.sh) works aswell:
```bash
brew install cmake tbb glfw openimageio
```