### PR TITLE
Verify fixes

### DIFF
--- a/kernels/common/rtcore.cpp
+++ b/kernels/common/rtcore.cpp
@@ -481,12 +481,12 @@ RTC_NAMESPACE_BEGIN;
 
     IntersectContext context(scene,user_context);
 #if !defined(EMBREE_RAY_PACKETS)
-    Ray4* ray4 = (Ray4*) rayhit;
+    RayHit4* rayhit4 = (RayHit4*)rayhit;
     for (size_t i=0; i<4; i++) {
       if (!valid[i]) continue;
-      RayHit ray1; ray4->get(i,ray1);
+      RayHit ray1; rayhit4->get(i,ray1);
       scene->intersectors.intersect((RTCRayHit&)ray1,&context);
-      ray4->set(i,ray1);
+      rayhit4->set(i,ray1);
     }
 #else
     scene->intersectors.intersect4(valid,*rayhit,&context);
@@ -512,12 +512,12 @@ RTC_NAMESPACE_BEGIN;
 
     IntersectContext context(scene,user_context);
 #if !defined(EMBREE_RAY_PACKETS)
-    Ray8* ray8 = (Ray8*) rayhit;
+    RayHit8* rayhit8 = (RayHit8*) rayhit;
     for (size_t i=0; i<8; i++) {
       if (!valid[i]) continue;
-      RayHit ray1; ray8->get(i,ray1);
+      RayHit ray1; rayhit8->get(i,ray1);
       scene->intersectors.intersect((RTCRayHit&)ray1,&context);
-      ray8->set(i,ray1);
+      rayhit8->set(i,ray1);
     }
 #else
     if (likely(scene->intersectors.intersector8))
@@ -545,12 +545,12 @@ RTC_NAMESPACE_BEGIN;
 
     IntersectContext context(scene,user_context);
 #if !defined(EMBREE_RAY_PACKETS)
-    Ray16* ray16 = (Ray16*) rayhit;
+    RayHit16* rayhit16 = (RayHit16*) rayhit;
     for (size_t i=0; i<16; i++) {
       if (!valid[i]) continue;
-      RayHit ray1; ray16->get(i,ray1);
+      RayHit ray1; rayhit16->get(i,ray1);
       scene->intersectors.intersect((RTCRayHit&)ray1,&context);
-      ray16->set(i,ray1);
+      rayhit16->set(i,ray1);
     }
 #else
     if (likely(scene->intersectors.intersector16))
@@ -732,12 +732,12 @@ RTC_NAMESPACE_BEGIN;
 
     IntersectContext context(scene,user_context);
 #if !defined(EMBREE_RAY_PACKETS)
-    RayHit4* ray4 = (RayHit4*) ray;
+    Ray4* ray4 = (Ray4*) ray;
     for (size_t i=0; i<4; i++) {
       if (!valid[i]) continue;
-      RayHit ray1; ray4->get(i,ray1);
+      Ray ray1; ray4->get(i,ray1);
       scene->intersectors.occluded((RTCRay&)ray1,&context);
-      ray4->geomID[i] = ray1.geomID; 
+      ray4->set(i,ray1);
     }
 #else
     scene->intersectors.occluded4(valid,*ray,&context);
@@ -763,10 +763,10 @@ RTC_NAMESPACE_BEGIN;
 
     IntersectContext context(scene,user_context);
 #if !defined(EMBREE_RAY_PACKETS)
-    RayHit8* ray8 = (RayHit8*) ray;
+    Ray8* ray8 = (Ray8*) ray;
     for (size_t i=0; i<8; i++) {
       if (!valid[i]) continue;
-      RayHit ray1; ray8->get(i,ray1);
+      Ray ray1; ray8->get(i,ray1);
       scene->intersectors.occluded((RTCRay&)ray1,&context);
       ray8->set(i,ray1);
     }
@@ -797,10 +797,10 @@ RTC_NAMESPACE_BEGIN;
 
     IntersectContext context(scene,user_context);
 #if !defined(EMBREE_RAY_PACKETS)
-    RayHit16* ray16 = (RayHit16*) ray;
+    Ray16* ray16 = (Ray16*) ray;
     for (size_t i=0; i<16; i++) {
       if (!valid[i]) continue;
-      RayHit ray1; ray16->get(i,ray1);
+      Ray ray1; ray16->get(i,ray1);
       scene->intersectors.occluded((RTCRay&)ray1,&context);
       ray16->set(i,ray1);
     }

--- a/tutorials/verify/verify.cpp
+++ b/tutorials/verify/verify.cpp
@@ -2544,6 +2544,10 @@ namespace embree
       rtcSetGeometryMask(hgeom1,2);
       rtcSetGeometryMask(hgeom2,4);
       rtcSetGeometryMask(hgeom3,8);
+      rtcCommitGeometry(hgeom0);
+      rtcCommitGeometry(hgeom1);
+      rtcCommitGeometry(hgeom2);
+      rtcCommitGeometry(hgeom3);
       rtcCommitScene (scene);
       AssertNoError(device);
       


### PR DESCRIPTION
Hi, 
Syoyo and I have noticed that the 'verify' executable creates various FAILED results, particularly when compiling with EMBREE_RAY_PACKETS=OFF

We provide a fix to the rtcIntersect4/8/16 and rtcOccluded4/8/16 functions for the rare case '!defined(EMBREE_RAY_PACKETS)'. This fixes invalid casts between RTCRayK/RTCRayHitK and RayK and RayHitK and ensures that proper set/get functions are applied for the internal emulation through Ray and RayHit.

In addition, we partially fix the cause for failure of the 'RayMasksTest' case.

Without Pull Request (with EMBREE_RAY_PACKETS=OFF):
[verify_sse2_before.txt](https://github.com/embree/embree/files/4272082/verify_sse2_before.txt)
With Pull Request (with EMBREE_RAY_PACKETS=OFF):
[verify_sse2_after.txt](https://github.com/embree/embree/files/4272081/verify_sse2_after.txt)


