### PR TITLE
Fix "see also" links by marking them separately

### DIFF
--- a/doc/src/api/RTC_GEOMETRY_TYPE_CURVE.md
+++ b/doc/src/api/RTC_GEOMETRY_TYPE_CURVE.md
@@ -262,4 +262,4 @@ queried using `rtcGetDeviceError`.
 
 #### SEE ALSO
 
-[rtcNewGeometry, RTCCurveFlags]
+[rtcNewGeometry], [RTCCurveFlags]


### PR DESCRIPTION
The previous version included two terms in a single [..., ...] expression,
which produces non-linkified output. This change separately marks each
referenced term for proper cross-referencing.