### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1376,7 +1376,7 @@ Possible properties to query are:
     0.  internal tasking system
     1.  Intel Threading Building Blocks (TBB)
     2.  Parallel Patterns Library (PPL)
--   `RTC_DEVICE_PROPERTY_COMMIT_JOIN_SUPPORTED`: Queries whether
+-   `RTC_DEVICE_PROPERTY_JOIN_COMMIT_SUPPORTED`: Queries whether
     `rtcJoinCommitScene` is supported. This is not the case when Embree
     is compiled with PPL or older versions of TBB.
 


### PR DESCRIPTION
In README.md one member of enum RTCDeviceProperty was misspelled.
Compare the definition in line 50 of [include/embree3/rtcore_device.h](https://github.com/embree/embree/blob/master/include/embree3/rtcore_device.h) 