### PR TITLE
Fix typos in #if and nonstandard implicit cast.

### DIFF
--- a/common/math/math.h
+++ b/common/math/math.h
@@ -13,7 +13,7 @@
 #include <immintrin.h>
 
 #if defined(__WIN32__)
-#if (__MSV_VER <= 1700)
+#if defined(_MSC_VER) && (_MSC_VER <= 1700)
 namespace std
 {
   __forceinline bool isinf ( const float x ) { return _finite(x) == 0; }
@@ -86,7 +86,7 @@ namespace embree
     return _mm_cvtss_f32(c);
   }
 
-#if defined(__WIN32__) && (__MSC_VER <= 1700)
+#if defined(__WIN32__) && defined(_MSC_VER) && (_MSC_VER <= 1700)
   __forceinline float nextafter(float x, float y) { if ((x<y) == (x>0)) return x*(1.1f+float(ulp)); else return x*(0.9f-float(ulp)); }
   __forceinline double nextafter(double x, double y) { return _nextafter(x, y); }
   __forceinline int roundf(float f) { return (int)(f + 0.5f); }

--- a/common/sys/library.cpp
+++ b/common/sys/library.cpp
@@ -27,7 +27,7 @@ namespace embree
 
   /* returns address of a symbol from the library */
   void* getSymbol(lib_t lib, const std::string& sym) {
-    return GetProcAddress(HMODULE(lib),sym.c_str());
+    return (void*)GetProcAddress(HMODULE(lib),sym.c_str());
   }
 
   /* closes the shared library */


### PR DESCRIPTION

Regarding the changes in math.h, it appears that `_MSC_VER` was typoed in preprocessor statements in two different ways: once as `__MSV_VER` and again as `__MSC_VER` (note the double underscore) which means they will be treated as 0. Combined with `<` or `<=`, it means that the check will be true on all compilers building for windows.

The typos in math.h (and missing defined(_MSC_VER)) caused the following errors when cross-compiling with `llvm-mingw` on a Linux system:
```
In file included from kernels/common/accelset.cpp:5:
In file included from kernels/common/scene.h:16:
In file included from kernels/common/scene_subdiv_mesh.h:11:
In file included from kernels/common/../subdiv/patch.h:6:
In file included from kernels/common/../subdiv/catmullclark_patch.h:6:
kernels/common/../subdiv/catmullclark_ring.h:365:20: error: call to 'isinf' is ambiguous
      if (unlikely(std::isinf(vertex_crease_weight)))
                   ^~~~~~~~~~
kernels/common/../../common/tasking/../sys/platform.h:152:48: note: expanded from macro 'unlikely'
#define unlikely(expr) __builtin_expect((bool)(expr),false)
                                               ^~~~
/opt/llvm-mingw/x86_64-w64-mingw32/include/c++/v1/math.h:491:1: note: candidate function
isinf(float __lcpp_x) _NOEXCEPT { return __libcpp_isinf(__lcpp_x); }
^
kernels/common/../../common/algorithms/../math/math.h:19:22: note: candidate function
  __forceinline bool isinf ( const float x ) { return _finite(x) == 0; }
```

The second instance guards what appear to be fallback implementations of `roundf` and `nextafter`.

One concern I have is these Visual Studio 2013(?) implementations of `nextafter(float, float)` and `roundf(float)` are actually wildly incorrect, and specifically `roundf` was likely being used on all windows builds:
- `nextafter(x, -1.0)` was unused except in tutorial code, but if it were used, as in tutorials/common/texture/texture2d.cpp, it would cause the texture dimensions to be multiplied by 0.9
- `roundf(float x)` seems mostly correct for float values which are representable as a 32-bit integer, but for those which are not, will cause some form of overflow. This seems like potential for bugs.

This PR will inadvertently fix these issues, by fixing the condition for the "fallback" implementations to be used. Hopefully nothing depended on the overflow mechanic of the old `roundf` implementation...

----

Regarding the other change, the missing (void*) cast in common/sys/library.cpp is apparently a non-standard Microsoft extension, allowed only in the Microsoft-compatible setting of clang, and not by default. Using the same command line as on Windows, this implicit cast from FARPROC to void* causes the following error.
```
common/sys/library.cpp:30:12: error: cannot initialize return object of type 'void *' with an rvalue of type 'FARPROC' (aka 'long long (*)()')
    return GetProcAddress(HMODULE(lib),sym.c_str());
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

By adding `-fms-compatibility` to the command line on a clang build, it is possible to reduce this to a warning instead of an error:
```
warning: implicit conversion between pointer-to-function and pointer-to-object is a Microsoft extension [-Wmicrosoft-cast]
```
However, it would be preferable to solve this by performing an *explicit cast* to `void*`.

Collectively, these two fixes allow embree to be cross compiled using llvm-mingw on Linux without any non-standard options.