### PR TITLE
Fix Newton-Raphson iteration for rcp() w/ AVX2.

### DIFF
--- a/common/math/vec3fa.h
+++ b/common/math/vec3fa.h
@@ -109,7 +109,10 @@ namespace embree
 #endif
 
 #if defined(__AVX2__)
-    const Vec3fa res = _mm_mul_ps(r.m128,_mm_fnmadd_ps(r.m128, a.m128, vfloat4(2.0f)));
+    // First, compute 1 - a * r (which will be very close to 0)
+    const Vec3fa h_n = _mm_fnmadd_ps(a.m128, r.m128, vfloat4(1.0));
+    // Then compute r + r * h_n
+    const Vec3fa res = _mm_fmadd_ps(r.m128, h_n.m128, r.m128);
 #else
     const Vec3fa res = _mm_mul_ps(r.m128,_mm_sub_ps(vfloat4(2.0f), _mm_mul_ps(r.m128, a.m128)));
     //return _mm_sub_ps(_mm_add_ps(r, r), _mm_mul_ps(_mm_mul_ps(r, r), a));

--- a/common/simd/vfloat4_sse2.h
+++ b/common/simd/vfloat4_sse2.h
@@ -275,7 +275,10 @@ namespace embree
 #endif
 
 #if defined(__AVX2__)
-    return _mm_mul_ps(r,_mm_fnmadd_ps(r, a, vfloat4(2.0f)));
+    // First, compute 1 - a * r (which will be very close to 0)
+    const vfloat4 h_n = _mm_fnmadd_ps(a, r, vfloat4(1.0f));
+    // Then compute r + r * h_n
+    return _mm_fmadd_ps(r, h_n, r);
 #else
     return _mm_mul_ps(r,_mm_sub_ps(vfloat4(2.0f), _mm_mul_ps(r, a)));
 #endif

--- a/common/simd/vfloat8_avx.h
+++ b/common/simd/vfloat8_avx.h
@@ -236,7 +236,10 @@ namespace embree
 #endif
 
 #if defined(__AVX2__)
-    return _mm256_mul_ps(r, _mm256_fnmadd_ps(r, a, vfloat8(2.0f)));
+    // First, compute 1 - a * r (which will be very close to 0)
+    const vfloat8 h_n = _mm256_fnmadd_ps(a, r, vfloat8(1.0f));
+    // Then compute r + r * h_n
+    return _mm256_fmadd_ps(r, h_n, r);
 #else
     return _mm256_mul_ps(r, _mm256_sub_ps(vfloat8(2.0f), _mm256_mul_ps(r, a)));
 #endif


### PR DESCRIPTION
The current rcp() code uses rcp_ps which is only somewhat
accurate. The Newton-Raphson iteration that Embree uses
to correct for it transforms the basic relation:

 2 * x - a * x * x

into:

 x * (2 - a * x)

But it's much more numerically accurate [1] to calculate:

 h_n = 1 - a * x (nearly 0, since a and x are inverses)
 res = x + x * h_n

This correction makes the various origin * rdir code in
the BVH intersectors (which are only enabled with AVX2+)
pass our tests, even on Intel boxes (AMD boxes were passing
because AMD's rcp approximation has generally higher accuracy).

[1] http://numbers.computation.free.fr/Constants/Algorithms/inverse.html