### PR TITLE
Fix undefined reference to `GridMesh` with `EMBREE_GEOMETRY_GRID` off

### DIFF
--- a/kernels/builders/primrefgen.cpp
+++ b/kernels/builders/primrefgen.cpp
@@ -184,6 +184,7 @@ namespace embree
 
     // special variants for grid meshes
 
+#if defined(EMBREE_GEOMETRY_GRID)
     PrimInfo createPrimRefArrayGrids(Scene* scene, mvector<PrimRef>& prims, mvector<SubGridBuildData>& sgrids)
     {
       PrimInfo pinfo(empty);
@@ -293,6 +294,7 @@ namespace embree
 
       return pinfo;
     }
+#endif
     
     // ====================================================================================================
     // ====================================================================================================


### PR DESCRIPTION
This fixes the following issue when linking downstream code compiled with GCC's
`-fsanitize=undefined` with `EMBREE_GEOMETRY_GRID` undefined:

> error: undefined reference to 'typeinfo for embree::GridMesh'

Co-authored-by: @JFonS

----

It might not be the best/most comprehensive fix, but it does fix the issue for us.

The issue happens when building https://github.com/godotengine/godot with `use_ubsan=yes` which enables GCC/Clang `-fsanitize=undefined`.

We use a stripped down version of Embree with only the files / codepaths that are relevant for our use cases:
https://github.com/godotengine/godot/blob/c03876837909b75704e8f7a576001466ef5f11eb/modules/raycast/godot_update_embree.py#L111-L126

And we reimplement the build step in our own SCons buildsystem instead of using the upstream CMake: https://github.com/godotengine/godot/blob/master/modules/raycast/SCsub

I haven't checked if the issue is reproducible with the official CMake buildsystem (I did try to inject `-fsanitize=undefined` in the CMake scripts a few months ago but with the default options Embree seems to take literally hours to build, so I gave up before reaching the linking step). But at the very least it seems clear that no code should be referring to `embree::GridMesh` when `EMBREE_GEOMETRY_GRID` is undefined.