### PR TITLE
thread: Add initial support for Android

### DIFF
--- a/common/sys/sysinfo.cpp
+++ b/common/sys/sysinfo.cpp
@@ -21,7 +21,11 @@ namespace embree
   
   std::string getPlatformName() 
   {
-#if defined(__LINUX__) && !defined(__64BIT__)
+#if defined(__ANDROID__) && !defined(__64BIT__)
+    return "Android (32bit)";
+#elif defined(__ANDROID__) && defined(__64BIT__)
+    return "Android (64bit)";
+#elif defined(__LINUX__) && !defined(__64BIT__)
     return "Linux (32bit)";
 #elif defined(__LINUX__) && defined(__64BIT__)
     return "Linux (64bit)";
@@ -618,7 +622,7 @@ namespace embree
     static int nThreads = -1;
     if (nThreads != -1) return nThreads;
 
-#if defined(__MACOSX__)
+#if defined(__MACOSX__) || defined(__ANDROID__)
     nThreads = sysconf(_SC_NPROCESSORS_ONLN); // does not work in Linux LXC container
     assert(nThreads);
 #else


### PR DESCRIPTION
This may not be all changes needed to actually use all of Embree on Android,
but it enables us to compile Embree for Android with NDK r21.4 for all
supported architectures: aarch64 armv7 x86_64 x86.

Co-authored-by: @JFonS

---

We're using this code in https://github.com/godotengine/godot to compile for Android successfully, though we haven't done a lot of testing yet to ensure that the features we use Embree for are fully functional on Android.