### PR TITLE
sys: Fixes for MinGW support

### DIFF
--- a/common/sys/platform.h
+++ b/common/sys/platform.h
@@ -99,7 +99,7 @@
 #define dll_import 
 #endif
 
-#ifdef __WIN32__
+#if defined(__WIN32__) && !defined(__MINGW32__)
 #if !defined(__noinline)
 #define __noinline             __declspec(noinline)
 #endif

--- a/common/sys/sysinfo.cpp
+++ b/common/sys/sysinfo.cpp
@@ -248,7 +248,7 @@ namespace embree
 #if defined(__X86_ASM__)
   __noinline int64_t get_xcr0() 
   {
-#if defined (__WIN32__)
+#if defined (__WIN32__) && !defined (__MINGW32__)
     int64_t xcr0 = 0; // int64_t is workaround for compiler bug under VS2013, Win32
     xcr0 = _xgetbv(0);
     return xcr0;

--- a/include/embree3/rtcore_common.h
+++ b/include/embree3/rtcore_common.h
@@ -19,7 +19,7 @@ typedef int ssize_t;
 #endif
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #  define RTC_ALIGN(...) __declspec(align(__VA_ARGS__))
 #else
 #  define RTC_ALIGN(...) __attribute__((aligned(__VA_ARGS__)))


### PR DESCRIPTION
Tested successfully in Godot to compile with MinGW-GCC and MinGW-Clang
for Windows.

This doesn't include needed changes to CMakeLists.txt to support using
a MinGW-GCC based toolchain to compile Embree with CMake.

Co-authored-by: @RandomShaper

Related to #279.