### PR TITLE
Don't override `NOMINMAX` and `likely` if already defined

### DIFF
--- a/common/sys/intrinsics.h
+++ b/common/sys/intrinsics.h
@@ -34,7 +34,9 @@
 #endif
 
 #if defined(__WIN32__)
-#  define NOMINMAX
+#  if !defined(NOMINMAX)
+#    define NOMINMAX
+#  endif
 #  include <windows.h>
 #endif
 

--- a/common/sys/platform.h
+++ b/common/sys/platform.h
@@ -149,12 +149,14 @@
   #define DELETED  = delete
 #endif
 
+#if !defined(likely)
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 #define   likely(expr) (expr)
 #define unlikely(expr) (expr)
 #else
 #define   likely(expr) __builtin_expect((bool)(expr),true )
 #define unlikely(expr) __builtin_expect((bool)(expr),false)
+#endif
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/common/tasking/taskschedulertbb.h
+++ b/common/tasking/taskschedulertbb.h
@@ -11,7 +11,7 @@
 #include "../sys/condition.h"
 #include "../sys/ref.h"
 
-#if defined(__WIN32__)
+#if defined(__WIN32__) && !defined(NOMINMAX)
 #  define NOMINMAX
 #endif
 


### PR DESCRIPTION
Co-authored-by: @JFonS

----

I'm not sure what the problem was exactly with those (we have had this patch downstream for a while), but I guess these redefinitions conflict with our own downstream.