### PR TITLE
Containing error when constructing patches from normal oriented curves

### DIFF
--- a/kernels/subdiv/linear_bezier_patch.h
+++ b/kernels/subdiv/linear_bezier_patch.h
@@ -106,22 +106,24 @@ namespace embree
           const Vec3fa dbt1 = cross(dn1,dp1) + cross(n1,ddp1);
             
           const Vec3fa k0  = normalize(bt0);
-          const Vec3fa dk0 = dnormalize(bt0,dbt0);
-          
+          Vec3fa dk0 = p0.w * dnormalize(bt0,dbt0);
+          dk0 *= min(1.0f, length(dp0) / length(dk0));
+
           const Vec3fa k1 = normalize(bt1);
-          const Vec3fa dk1 = dnormalize(bt1,dbt1);
-                    
+          Vec3fa dk1 = p1.w * dnormalize(bt1,dbt1);
+          dk1 *= min(1.0f, length(dp1) / length(dk1));
+
           const Vec3fa l0 = p0 - p0.w*k0;
-          const Vec3fa dl0 = dp0 - (dp0.w*k0 + p0.w*dk0);
+          const Vec3fa dl0 = dp0 - (dp0.w*k0 + dk0);
 
           const Vec3fa r0 = p0 + p0.w*k0;
-          const Vec3fa dr0 = dp0 + (dp0.w*k0 + p0.w*dk0);
+          const Vec3fa dr0 = dp0 + (dp0.w*k0 + dk0);
 
           const Vec3fa l1 = p1 - p1.w*k1;
-          const Vec3fa dl1 = dp1 - (dp1.w*k1 + p1.w*dk1);
+          const Vec3fa dl1 = dp1 - (dp1.w*k1 + dk1);
 
           const Vec3fa r1 = p1 + p1.w*k1;
-          const Vec3fa dr1 = dp1 + (dp1.w*k1 + p1.w*dk1);
+          const Vec3fa dr1 = dp1 + (dp1.w*k1 + dk1);
 
           const float scale = 1.0f/3.0f;
           CubicBezierCurve<V> L(l0,l0+scale*dl0,l1-scale*dl1,l1);


### PR DESCRIPTION
Hi Embree team,

We noticed that the code responsible for the construction of the Bezier patches from normal oriented curves tends to degenerate as curvature increases at the endpoints. The control points of the resulting patch can end up being tens of times larger than the bounding box of the center curve.
While this is probably a corner case, as the radius of the curvature tends to be smaller than the radius of the curve itself, it also results in undesirable behavior, affecting the look of the entire scene.

This is an attempt to control that error, the change proposed in this PR prevents the derivative of the bitangent to grow longer than the derivative of the position when constructing the left and right curve. The curve remains well behaved in extreme conditions, with the side effect of a minor shrink when it twists - from my testing.
This specific change is derived from trying to prevent the offset curves to have tangents going in the opposite direction than those of the center curve, which we observed to be an effective method of controlling this extreme behavior for both left and right curves.

I am also making this PR in the hope to better understand the current construction so that maybe we can convene on a better solution together.

This is the result of rendering a RTC_GEOMETRY_TYPE_NORMAL_ORIENTED_BSPLINE_CURVE with control points
```
  { 0.f, 0.f, 0.f, 1.f },
  { 100.f, 0.f, 0.f, 1.f },
  { 100.f, 100.f, 0.f, 1.f },
  { 101.f, 0.f, 0.f, 1.f }
  ```
and constant normals of (0, 0, 1)
![embree_bspline0](https://user-images.githubusercontent.com/2072636/150677537-cc03c450-9da8-447a-9b07-a0aa7c33c193.png)

Or a more extreme case, similar to what we were unlucky to encounter in production assets.
```
  { 0.f, 0.f, 0.f, 1.f },
  { 100.f, 0.f, 0.f, 1.f },
  { 100.f, 100.f, 0.f, 1.f },
  { 100.1f, 0.f, 0.f, 1.f }
  ```
and constant normals of (0, 0, 1)
![embree_bspline_old1](https://user-images.githubusercontent.com/2072636/150677675-6ffb93db-d786-4618-b989-d63274eb5bcb.png)


On the other hand, this is the last example with the change proposed in the PR
![embree_bspline1_new](https://user-images.githubusercontent.com/2072636/150677559-e006f5bd-0f4d-4345-9a14-63b901cf34bd.png)


And this is how the new code affects the curves in the curve_geometry example, the shrunken one is the result in this PR.
![Screencast from 2022-01-21 03 00 10 PM (online-video-cutter com)](https://user-images.githubusercontent.com/2072636/150677839-9409b3d6-cd01-471d-8594-f3d492a29e38.gif)


Having varying normals can mitigate the error, but doesn't fundamentally prevent the issue.
I have also done some tests with more sensible curvature and a high radius, to highlight the limitation of this clamping, but haven't been able to find a case which is significantly affected. 

Here is how the control points of the input B-spline affect the construction, visualized in 2D. The blue Beziers are the new construction and the red Beziers are the current implementation.  

Looking forward to hearing your thoughts, cheers.

https://user-images.githubusercontent.com/2072636/150678467-bed27414-a29e-4636-aef4-5422ed5a7b4e.mp4



