### PR TITLE
add OpenBSD support

### DIFF
--- a/common/math/math.h
+++ b/common/math/math.h
@@ -169,6 +169,7 @@ namespace embree
 
   __forceinline      int min(int      a, int      b) { return a<b ? a:b; }
   __forceinline unsigned min(unsigned a, unsigned b) { return a<b ? a:b; }
+  __forceinline     long min(long     a, long     b) { return a<b ? a:b; }
   __forceinline  int64_t min(int64_t  a, int64_t  b) { return a<b ? a:b; }
   __forceinline    float min(float    a, float    b) { return a<b ? a:b; }
   __forceinline   double min(double   a, double   b) { return a<b ? a:b; }
@@ -189,6 +190,7 @@ namespace embree
 
   __forceinline      int max(int      a, int      b) { return a<b ? b:a; }
   __forceinline unsigned max(unsigned a, unsigned b) { return a<b ? b:a; }
+  __forceinline     long max(long     a, long     b) { return a<b ? b:a; }
   __forceinline  int64_t max(int64_t  a, int64_t  b) { return a<b ? b:a; }
   __forceinline    float max(float    a, float    b) { return a<b ? b:a; }
   __forceinline   double max(double   a, double   b) { return a<b ? b:a; }

--- a/common/sys/sysinfo.cpp
+++ b/common/sys/sysinfo.cpp
@@ -575,6 +575,29 @@ namespace embree
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
+/// OpenBSD Platform
+////////////////////////////////////////////////////////////////////////////////
+
+#if defined(__OpenBSD__)
+namespace embree
+{
+  std::string getExecutableFileName()
+  {
+    /* not possible on OpenBSD.  if you need it, save argv[0] */
+    return "";
+  }
+
+  size_t getVirtualMemoryBytes() {
+    return 0;
+  }
+   
+  size_t getResidentMemoryBytes() {
+    return 0;
+  }
+}
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
 /// Mac OS X Platform
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -626,7 +649,7 @@ namespace embree
     static int nThreads = -1;
     if (nThreads != -1) return nThreads;
 
-#if defined(__MACOSX__) || defined(__ANDROID__)
+#if defined(__MACOSX__) || defined(__ANDROID__) || defined(__OpenBSD__)
     nThreads = sysconf(_SC_NPROCESSORS_ONLN); // does not work in Linux LXC container
     assert(nThreads);
 #elif defined(__EMSCRIPTEN__)


### PR DESCRIPTION
Hello,

as per title, this pr fixes some issues found when trying to build bits of embree code vendored in [Godot](https://github.com/godotengine/godot) on OpenBSD.

* I'm adding an implementation of max and min for `long`s because size_t and ssize_t are typedef'd to long and it fails in parallel_partition.h due to an ambiguous call otherwise;
* OpenBSD doesn't have pthread_getaffinity_np in pthread_np.h; use sysctl like macos and android then.
* regarding sysinfo... I'm just faking it.  There isn't any API to get the path to the current executable, save `argv[0]` if you need it.

we kept these patches in for building the Godot package for a while (see [here](https://github.com/openbsd/ports/blob/master/games/godot/patches/patch-thirdparty_embree_common_math_math_h) and [here](https://github.com/openbsd/ports/blob/master/games/godot/patches/patch-thirdparty_embree_common_sys_sysinfo_cpp).)