### PR TITLE
Fix compilation issues on macOS 12.5 and Apple clang version 13.1.6

### DIFF
--- a/common/sys/vector.h
+++ b/common/sys/vector.h
@@ -133,8 +133,9 @@ namespace embree
       __forceinline void clear() 
       {
         /* destroy elements */
-        for (size_t i=0; i<size_active; i++)
-          alloc.destroy(&items[i]);
+        for (size_t i=0; i<size_active; i++){
+          items[i].~T();
+        }
         
         /* free memory */
         alloc.deallocate(items,size_alloced); 
@@ -178,8 +179,9 @@ namespace embree
         /* destroy elements */
         if (new_active < size_active) 
         {
-          for (size_t i=new_active; i<size_active; i++)
-            alloc.destroy(&items[i]);
+          for (size_t i=new_active; i<size_active; i++){
+            items[i].~T();
+          }
           size_active = new_active;
         }
 
@@ -195,7 +197,7 @@ namespace embree
         items = alloc.allocate(new_alloced);
         for (size_t i=0; i<size_active; i++) {
           ::new (&items[i]) T(std::move(old_items[i]));
-          alloc.destroy(&old_items[i]);
+          old_items[i].~T();
         }
 
         for (size_t i=size_active; i<new_active; i++) {


### PR DESCRIPTION
`alloc.destroy` lead to compilation issues. This PR fix those compilation issues.

I get for instance the following error (on macOS M1 with Apple clang version 13.1.6 (clang-1316.0.21.2.5)) if the fix is **not** applied:

```
external/embree/kernels/common/../../common/sys/vector.h:137:17: error: no member named 'destroy' in 'std::allocator<embree::BufferView<char>>'
          alloc.destroy(&items[i]);
          ~~~~~ ^
external/embree/kernels/common/../../common/sys/vector.h:30:9: note: in instantiation of member function 'embree::vector_t<embree::BufferView<char>, std::allocator<embree::BufferView<char>>>::clear' requested here
        clear();
        ^
external/embree/kernels/common/scene_points.h:13:10: note: in instantiation of member function 'embree::vector_t<embree::BufferView<char>, std::allocator<embree::BufferView<char>>>::~vector_t' requested here
  struct Points : public Geometry
         ^
In file included from external/embree/kernels/common/scene_points.cpp:4:
In file included from external/embree/kernels/common/scene_points.h:6:
In file included from external/embree/kernels/common/../subdiv/../common/buffer.h:6:
In file included from external/embree/kernels/common/../subdiv/../common/default.h:8:
In file included from external/embree/kernels/common/../../common/tasking/../sys/thread.h:9:
```

Fixes https://github.com/embree/embree/issues/385