### PR TITLE
Fix build in C++20 mode

### DIFF
--- a/common/sys/vector.h
+++ b/common/sys/vector.h
@@ -127,14 +127,14 @@ namespace embree
       {
         assert(!empty());
         size_active--;
-        alloc.destroy(&items[size_active]);
+        std::allocator_traits<decltype(alloc)>::destroy(alloc, &items[size_active]);
       }
 
       __forceinline void clear() 
       {
         /* destroy elements */
         for (size_t i=0; i<size_active; i++)
-          alloc.destroy(&items[i]);
+          std::allocator_traits<decltype(alloc)>::destroy(alloc, &items[i]);
         
         /* free memory */
         alloc.deallocate(items,size_alloced); 
@@ -179,7 +179,7 @@ namespace embree
         if (new_active < size_active) 
         {
           for (size_t i=new_active; i<size_active; i++)
-            alloc.destroy(&items[i]);
+            std::allocator_traits<decltype(alloc)>::destroy(alloc, &items[i]);
           size_active = new_active;
         }
 
@@ -195,7 +195,7 @@ namespace embree
         items = alloc.allocate(new_alloced);
         for (size_t i=0; i<size_active; i++) {
           ::new (&items[i]) T(std::move(old_items[i]));
-          alloc.destroy(&old_items[i]);
+          std::allocator_traits<decltype(alloc)>::destroy(alloc, &old_items[i]);
         }
 
         for (size_t i=size_active; i<new_active; i++) {

--- a/common/sys/vector.h
+++ b/common/sys/vector.h
@@ -127,14 +127,14 @@ namespace embree
       {
         assert(!empty());
         size_active--;
-        std::allocator_traits<decltype(alloc)>::destroy(alloc, &items[size_active]);
+        std::allocator_traits<allocator>::destroy(alloc, &items[size_active]);
       }
 
       __forceinline void clear() 
       {
         /* destroy elements */
         for (size_t i=0; i<size_active; i++)
-          std::allocator_traits<decltype(alloc)>::destroy(alloc, &items[i]);
+          std::allocator_traits<allocator>::destroy(alloc, &items[i]);
         
         /* free memory */
         alloc.deallocate(items,size_alloced); 
@@ -179,7 +179,7 @@ namespace embree
         if (new_active < size_active) 
         {
           for (size_t i=new_active; i<size_active; i++)
-            std::allocator_traits<decltype(alloc)>::destroy(alloc, &items[i]);
+            std::allocator_traits<allocator>::destroy(alloc, &items[i]);
           size_active = new_active;
         }
 
@@ -195,7 +195,7 @@ namespace embree
         items = alloc.allocate(new_alloced);
         for (size_t i=0; i<size_active; i++) {
           ::new (&items[i]) T(std::move(old_items[i]));
-          std::allocator_traits<decltype(alloc)>::destroy(alloc, &old_items[i]);
+          std::allocator_traits<allocator>::destroy(alloc, &old_items[i]);
         }
 
         for (size_t i=size_active; i<new_active; i++) {


### PR DESCRIPTION
std::allocator<Foo>::destroy has been deprecated, and removed in C++20. Use std::allocator_traits<std::allocator<Foo>>::destroy instead.