### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ You can download and install embree using the [vcpkg](https://github.com/Microso
     cd vcpkg
     ./bootstrap-vcpkg.sh
     ./vcpkg integrate install
-    ./vcpkg install embree
+    ./vcpkg install embree2
 
 The embree port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 

--- a/README.md
+++ b/README.md
@@ -360,6 +360,17 @@ example, to build the Embree library in parallel use
 
     cmake --build . --config Release --target embree -- /m
 
+### Building embree - Using vcpkg
+
+You can download and install embree using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install embree
+
+The embree port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 CMake Configuration
 -------------------


### PR DESCRIPTION
embree is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for embree and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build embree, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/embree2/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)