### PR TITLE
Section title format fix for"Embree Support and Contact"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ transparently transitioning to 2MB pages.
 Embree is optimized for Intel CPUs supporting SSE, AVX, AVX2, and
 AVX-512 instructions. Embree requires at least an x86 CPU with support for
 SSE2 or an Apple M1 CPU.
+
 Embree Support and Contact
 --------------------------
 


### PR DESCRIPTION
Added a new line to fix formatting issue that was mixing the section title with the previous paragraph.