### PR TITLE
Changes required for Windows ARM64

### DIFF
--- a/common/simd/arm/sse2neon.h
+++ b/common/simd/arm/sse2neon.h
@@ -1729,12 +1729,14 @@ FORCE_INLINE __m128 _mm_div_ss(__m128 a, __m128 b)
 #define _mm_extract_pi16(a, imm) \
     (int32_t) vget_lane_u16(vreinterpret_u16_m64(a), (imm))
 
+#if !defined(_WIN32)
 // Free aligned memory that was allocated with _mm_malloc.
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_free
 FORCE_INLINE void _mm_free(void *addr)
 {
     free(addr);
 }
+#endif
 
 // Macro: Get the flush zero bits from the MXCSR control and status register.
 // The flush zero may contain any of the following flags: _MM_FLUSH_ZERO_ON or
@@ -1913,6 +1915,7 @@ FORCE_INLINE __m128i _mm_loadu_si64(const void *p)
         vcombine_s64(vld1_s64((const int64_t *) p), vdup_n_s64(0)));
 }
 
+#if !defined(_WIN32)
 // Allocate aligned blocks of memory.
 // https://software.intel.com/en-us/
 //         cpp-compiler-developer-guide-and-reference-allocating-and-freeing-aligned-memory-blocks
@@ -1927,6 +1930,7 @@ FORCE_INLINE void *_mm_malloc(size_t size, size_t align)
         return ptr;
     return NULL;
 }
+#endif
 
 // Conditionally store 8-bit integer elements from a into memory using mask
 // (elements are not stored when the highest bit is not set in the corresponding

--- a/common/sys/intrinsics.h
+++ b/common/sys/intrinsics.h
@@ -89,7 +89,7 @@ namespace embree
 #endif
   }
   
-#if defined(__X86_64__)
+#if defined(__X86_64__) || defined (__aarch64__)
   __forceinline size_t bsf(size_t v) {
 #if defined(__AVX2__) 
     return _tzcnt_u64(v);
@@ -113,7 +113,7 @@ namespace embree
     return i;
   }
   
-#if defined(__X86_64__)
+#if defined(__X86_64__) || defined (__aarch64__)
   __forceinline size_t bscf(size_t& v) 
   {
     size_t i = bsf(v);
@@ -138,7 +138,7 @@ namespace embree
 #endif
   }
   
-#if defined(__X86_64__)
+#if defined(__X86_64__) || defined (__aarch64__)
   __forceinline size_t bsr(size_t v) {
 #if defined(__AVX2__) 
     return 63 -_lzcnt_u64(v);

--- a/include/embree3/rtcore_common.h
+++ b/include/embree3/rtcore_common.h
@@ -12,7 +12,7 @@
 RTC_NAMESPACE_BEGIN
 
 #if defined(_WIN32)
-#if defined(_M_X64)
+#if defined(_M_X64) || defined(_M_ARM64)
 typedef long long ssize_t;
 #else
 typedef int ssize_t;


### PR DESCRIPTION
Just a few changes in order to make embree compile for arm64-windows target.
Note: clang-cl must be used for NEON