### PR TITLE
include missing headers

### DIFF
--- a/common/sys/vector.h
+++ b/common/sys/vector.h
@@ -5,6 +5,7 @@
 
 #include "alloc.h"
 #include <algorithm>
+#include <type_traits>
 
 namespace embree
 {

--- a/common/tasking/taskschedulerinternal.h
+++ b/common/tasking/taskschedulerinternal.h
@@ -14,6 +14,7 @@
 #include "../sys/atomic.h"
 #include "../math/range.h"
 
+#include <exception>
 #include <list>
 
 namespace embree


### PR DESCRIPTION
Fixes a compile error with xcode when compiling in c++23.