### PR TITLE
Include Windows header and define NOMINMAX for Windows ARM64 builds

### DIFF
--- a/common/simd/arm/sse2neon.h
+++ b/common/simd/arm/sse2neon.h
@@ -109,6 +109,16 @@
 #define SSE2NEON_ALLOC_DEFINED
 #endif
 
+/* Include Windows.h and define NOMINMAX
+ * for Windows ARM64 builds
+ */
+#if defined(__WIN32__)
+#  if !defined(NOMINMAX)
+#    define NOMINMAX
+#  endif
+#  include <windows.h>
+#endif
+
 /* If using MSVC */
 #ifdef _MSC_VER
 #include <intrin.h>


### PR DESCRIPTION
PR Description:

- The compilation of Embree library failed on Windows ARM64 due to a missing definition of the DWORD type and macro conflicts caused by min and max definitions.
- The build failures occurred because of the omission of <windows.h> before using Windows specific typedefs in sse2neon.h, and the NOMINMAX macro was not defined to suppress min/max macro expansions that conflict with standard C++ functions. This PR adds a guarded include of <windows.h> for Windows ARM64 builds and defines NOMINMAX to prevent the conflicts.