### PR TITLE
Fix Win32/ARM build

### DIFF
--- a/common/simd/arm/sse2neon.h
+++ b/common/simd/arm/sse2neon.h
@@ -9038,7 +9038,7 @@ FORCE_INLINE int _sse2neon_sido_negative(int res, int lb, int imm8, int bound)
 FORCE_INLINE int _sse2neon_clz(unsigned int x)
 {
 #if _MSC_VER
-    DWORD cnt = 0;
+    unsigned long cnt = 0;
     if (_BitScanForward(&cnt, x))
         return cnt;
     return 32;
@@ -9050,7 +9050,7 @@ FORCE_INLINE int _sse2neon_clz(unsigned int x)
 FORCE_INLINE int _sse2neon_ctz(unsigned int x)
 {
 #if _MSC_VER
-    DWORD cnt = 0;
+    unsigned long cnt = 0;
     if (_BitScanReverse(&cnt, x))
         return 31 - cnt;
     return 32;


### PR DESCRIPTION
The wrong type (DWORD instead of usngined long) was used for bitscan.