### PR TITLE
Add quotes to prevent potential word splittings

### DIFF
--- a/scripts/download_gfx.sh
+++ b/scripts/download_gfx.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if [ -z $3 ]; then
+if [ -z "$3" ]; then
   echo "ERROR: usage $0 gfx-driver target-directory token"
   echo "    gfx-driver: URL to the driver packages relative to artifactory URL (e.g. gfx-driver-builds/ci/master/gfx-driver-ci-master-9999/artifacts/Linux/Ubuntu/22.04/Release"
   echo "    token: access token to (artifactory) repository"
@@ -21,8 +21,8 @@ fi
 URL=${ARTIFACTORY_URL}"/"${GFX_DRIVER}/
 
 CUR_DIR=$(pwd)
-mkdir -p /tmp/${GFX_DRIVER}
-cd /tmp/${GFX_DRIVER}
+mkdir -p "/tmp/${GFX_DRIVER}"
+cd "/tmp/${GFX_DRIVER}"
 
 if [[ $GFX_DRIVER == *"linux"* ]] || [[ $GFX_DRIVER == *"Linux"* ]] ; then
   echo "Downloading Linux driver packages using"
@@ -30,7 +30,7 @@ if [[ $GFX_DRIVER == *"linux"* ]] || [[ $GFX_DRIVER == *"Linux"* ]] ; then
   echo "  GFX_DRIVER=${GFX_DRIVER}"
   echo "  DST_DIR=${DST_DIR}"
   echo "  TOKEN=${TOKEN}"
-  
+
   if [[ $GFX_DRIVER == *"open-linux"* ]] ; then
     DEBS="*"
   elif [[ $GFX_DRIVER == *"neo-releases"* ]] ; then
@@ -40,29 +40,29 @@ if [[ $GFX_DRIVER == *"linux"* ]] || [[ $GFX_DRIVER == *"Linux"* ]] ; then
   else
     DEBS="level-zero|intel-level-zero-gpu|intel-opencl-icd|libigc1|libigc-tools|libigdfcl1|libigdgmm"
   fi
-      
-  PACKAGES=$(curl -H "X-JFrog-Art-Api:$TOKEN" -s $URL |
+
+  PACKAGES=$(curl -H "X-JFrog-Art-Api:$TOKEN" -s "$URL" |
      sed 's/<a href/\n<a href/g' | sed 's/.deb"/.deb"\n/g' |
-     grep -o '".*"' | grep deb | tr -d '"' | grep -E $DEBS |
+     grep -o '".*"' | grep deb | tr -d '"' | grep -E "$DEBS" |
      grep -v devel | grep -v dev | grep -v debuginfo)
 
   mkdir -p install
   for package in ${PACKAGES}
   do
     echo "Download and install ${package}"
-    curl -H "X-JFrog-Art-Api:${TOKEN}" -s -O ${URL}${package}
-    dpkg -x $package ./install
+    curl -H "X-JFrog-Art-Api:${TOKEN}" -s -O "${URL}${package}"
+    dpkg -x "${package}" ./install
   done
 
-  mkdir -p ${DST_DIR}/${GFX_DRIVER}
-  cp -r * ${DST_DIR}/${GFX_DRIVER}/
+  mkdir -p "${DST_DIR}/${GFX_DRIVER}"
+  cp -r * "${DST_DIR}/${GFX_DRIVER}/"
 
   # fix path of libigdrcl in intel.icd file for local installation
-  echo "${DST_DIR}/${GFX_DRIVER}/install/usr/lib/x86_64-linux-gnu/intel-opencl/libigdrcl.so" > ${DST_DIR}/${GFX_DRIVER}/install/etc/OpenCL/vendors/intel.icd
+  echo "${DST_DIR}/${GFX_DRIVER}/install/usr/lib/x86_64-linux-gnu/intel-opencl/libigdrcl.so" > "${DST_DIR}/${GFX_DRIVER}/install/etc/OpenCL/vendors/intel.icd"
 
   echo "Driver installed to ${DST_DIR}/${GFX_DRIVER}/install"
 
-elif [[ $GFX_DRIVER == *"Windows"* ]]; then 
+elif [[ $GFX_DRIVER == *"Windows"* ]]; then
   echo "Downloading Windows driver packages using"
   echo "  ARTIFACTORY_URL=${ARTIFACTORY_URL}"
   echo "  GFX_DRIVER=${GFX_DRIVER}"
@@ -70,9 +70,9 @@ elif [[ $GFX_DRIVER == *"Windows"* ]]; then
   echo "  TOKEN=${TOKEN}"
 
   echo "Download Installer-Release"
-  curl -H "X-JFrog-Art-Api:${TOKEN}" -s -O ${URL}Installer-Release-64-bit.7z
+  curl -H "X-JFrog-Art-Api:${TOKEN}" -s -O "${URL}Installer-Release-64-bit.7z"
   echo "Download Ocloc-Release"
-  curl -H "X-JFrog-Art-Api:${TOKEN}" -s -O ${URL}Ocloc-Release-64-bit.7z
+  curl -H "X-JFrog-Art-Api:${TOKEN}" -s -O "${URL}Ocloc-Release-64-bit.7z"
 
   echo "Unpacking Installer-Release"
   7z x Installer-Release-64-bit.7z
@@ -80,17 +80,17 @@ elif [[ $GFX_DRIVER == *"Windows"* ]]; then
   7z x Ocloc-Release-64-bit.7z
 
   rm Installer-Release-64-bit.7z Ocloc-Release-64-bit.7z
-  mkdir -p ${DST_DIR}/${GFX_DRIVER}
-  cp -r * ${DST_DIR}/${GFX_DRIVER}
+  mkdir -p "${DST_DIR}/${GFX_DRIVER}"
+  cp -r * "${DST_DIR}/${GFX_DRIVER}"
 
-  chmod -R +x ${DST_DIR}/${GFX_DRIVER}
+  chmod -R +x "${DST_DIR}/${GFX_DRIVER}"
 
   echo "Driver installed to ${DST_DIR}/${GFX_DRIVER}"
 else
   echo "Platform could not be detected from gfx-driver URL"
 fi
 
-cd ${CUR_DIR}
-rm -rf /tmp/${GFX_DRIVER}
+cd "${CUR_DIR}"
+rm -rf "/tmp/${GFX_DRIVER}"
 
 


### PR DESCRIPTION
As the title suggests, this PR includes the commit that adds quotes to several commands in `scripts/download_gfx.sh` to prevent potential word splittings (related to <https://www.shellcheck.net/wiki/SC2086>). In particular, the previous line of `rm -rf /tmp/${GFX_DRIVER}` is concerning, since `${GFX_DRIVER}` is unquoted, (1) if it contains whitespaces, it would be split into multiple arguments to `rm -rf`, and (2) if it is empty or resolves unexpectedly, the command becomes `rm -rf /tmp/`, which is even more catastrophic. Other quotes are added more for the sake of consistency, even though they do address the valid concern of word splitting (but they are not as concerning as `rm -rf /tmp/${GFX_DRIVER}`).