### PR TITLE
Curves: reduce transcendentals, divergence, and loads on Intel iGPU

### DIFF
--- a/kernels/geometry/curveNi_intersector.h
+++ b/kernels/geometry/curveNi_intersector.h
@@ -27,12 +27,8 @@ namespace embree
       {
         const size_t N = prim.N;
 #if defined(EMBREE_SYCL_SUPPORT) && defined(__SYCL_DEVICE_ONLY__)
-        /* offset (12 B) and scale (4 B) live in 16 contiguous bytes; loading
-           them as 4 adjacent floats lets the SYCL/IGC compiler emit a single
-           coalesced 16-byte load instead of one Vec3f load + one scalar load. */
-        const float* offset_scale = (const float*)prim.offset(N);
-        const Vec3fa offset(offset_scale[0], offset_scale[1], offset_scale[2]);
-        const float scale = offset_scale[3];
+        const Vec3fa offset = *prim.offset(N);
+        const float scale  = *prim.scale(N);
 #else
         const vfloat4 offset_scale = vfloat4::loadu(prim.offset(N));
         const Vec3fa offset = Vec3fa(offset_scale);
@@ -313,10 +309,8 @@ namespace embree
       {
         const size_t N = prim.N;
 #if defined(EMBREE_SYCL_SUPPORT) && defined(__SYCL_DEVICE_ONLY__)
-        /* see CurveNiIntersector1::intersect for rationale of this 4xfloat load */
-        const float* offset_scale = (const float*)prim.offset(N);
-        const Vec3fa offset(offset_scale[0], offset_scale[1], offset_scale[2]);
-        const float scale = offset_scale[3];
+        const Vec3fa offset = *prim.offset(N);
+        const float scale  = *prim.scale(N);
 #else
         const vfloat4 offset_scale = vfloat4::loadu(prim.offset(N));
         const Vec3fa offset = Vec3fa(offset_scale);

--- a/kernels/geometry/curveNi_intersector.h
+++ b/kernels/geometry/curveNi_intersector.h
@@ -27,8 +27,12 @@ namespace embree
       {
         const size_t N = prim.N;
 #if defined(EMBREE_SYCL_SUPPORT) && defined(__SYCL_DEVICE_ONLY__)
-        const Vec3fa offset = *prim.offset(N);
-        const float scale  = *prim.scale(N);
+        /* offset (12 B) and scale (4 B) live in 16 contiguous bytes; loading
+           them as 4 adjacent floats lets the SYCL/IGC compiler emit a single
+           coalesced 16-byte load instead of one Vec3f load + one scalar load. */
+        const float* offset_scale = (const float*)prim.offset(N);
+        const Vec3fa offset(offset_scale[0], offset_scale[1], offset_scale[2]);
+        const float scale = offset_scale[3];
 #else
         const vfloat4 offset_scale = vfloat4::loadu(prim.offset(N));
         const Vec3fa offset = Vec3fa(offset_scale);
@@ -309,8 +313,10 @@ namespace embree
       {
         const size_t N = prim.N;
 #if defined(EMBREE_SYCL_SUPPORT) && defined(__SYCL_DEVICE_ONLY__)
-        const Vec3fa offset = *prim.offset(N);
-        const float scale  = *prim.scale(N);
+        /* see CurveNiIntersector1::intersect for rationale of this 4xfloat load */
+        const float* offset_scale = (const float*)prim.offset(N);
+        const Vec3fa offset(offset_scale[0], offset_scale[1], offset_scale[2]);
+        const float scale = offset_scale[3];
 #else
         const vfloat4 offset_scale = vfloat4::loadu(prim.offset(N));
         const Vec3fa offset = Vec3fa(offset_scale);

--- a/kernels/geometry/curve_intersector_distance.h
+++ b/kernels/geometry/curve_intersector_distance.h
@@ -103,38 +103,49 @@ namespace embree
         const NativeCurve3fa curve3Di(v0,v1,v2,v3);
         const NativeCurve3fa curve3D = enlargeRadiusToMinWidth(context,geom,ray.org,curve3Di);
         const NativeCurve3fa curve2D = curve3D.xfm_pr(pre.ray_space,ray.org);
-      
-        /* evaluate the bezier curve */
-        vboolx valid = vfloatx(step) < vfloatx(float(N));
-        const Vec4vfx p0 = curve2D.template eval0<W>(0,N);
-        const Vec4vfx p1 = curve2D.template eval1<W>(0,N);
 
-        /* approximative intersection with cone */
-        const Vec4vfx v = p1-p0;
-        const Vec4vfx w = -p0;
-        const vfloatx d0 = madd(w.x,v.x,w.y*v.y);
-        const vfloatx d1 = madd(v.x,v.x,v.y*v.y);
-        const vfloatx u = clamp(d0*rcp(d1),vfloatx(zero),vfloatx(one));
-        const Vec4vfx p = madd(u,v,p0);
-        const vfloatx t = p.z*pre.depth_scale;
-        const vfloatx d2 = madd(p.x,p.x,p.y*p.y); 
-        const vfloatx r = p.w;
-        const vfloatx r2 = r*r;
-        valid &= (d2 <= r2) & (vfloatx(ray.tnear()) <= t) & (t <= vfloatx(ray.tfar));
-        if (EMBREE_CURVE_SELF_INTERSECTION_AVOIDANCE_FACTOR != 0.0f) 
-          valid &= t > float(EMBREE_CURVE_SELF_INTERSECTION_AVOIDANCE_FACTOR)*r*pre.depth_scale; // ignore self intersections
-
-        /* update hit information */
         bool ishit = false;
-        if (unlikely(any(valid))) {
-          DistanceCurveHit<NativeCurve3fa,W> hit(valid,u,0.0f,t,0,N,curve3D);
-          ishit = ishit | epilog(valid,hit);
-        }
+        int i = 0;
 
-        if (unlikely(W < N)) 
+#if !defined(__SYCL_DEVICE_ONLY__)
+        /* unrolled first iteration: on CPU SIMD this lets the compiler keep
+           the first chunk of segments in registers and skip the loop overhead.
+           On SYCL (W=1) it duplicates code without benefit and just bloats the
+           kernel, so the SYCL path falls straight into the unified loop. */
+        {
+          /* evaluate the bezier curve */
+          vboolx valid = vfloatx(step) < vfloatx(float(N));
+          const Vec4vfx p0 = curve2D.template eval0<W>(0,N);
+          const Vec4vfx p1 = curve2D.template eval1<W>(0,N);
+
+          /* approximative intersection with cone */
+          const Vec4vfx v = p1-p0;
+          const Vec4vfx w = -p0;
+          const vfloatx d0 = madd(w.x,v.x,w.y*v.y);
+          const vfloatx d1 = madd(v.x,v.x,v.y*v.y);
+          const vfloatx u = clamp(d0*rcp(d1),vfloatx(zero),vfloatx(one));
+          const Vec4vfx p = madd(u,v,p0);
+          const vfloatx t = p.z*pre.depth_scale;
+          const vfloatx d2 = madd(p.x,p.x,p.y*p.y);
+          const vfloatx r = p.w;
+          const vfloatx r2 = r*r;
+          valid &= (d2 <= r2) & (vfloatx(ray.tnear()) <= t) & (t <= vfloatx(ray.tfar));
+          if (EMBREE_CURVE_SELF_INTERSECTION_AVOIDANCE_FACTOR != 0.0f)
+            valid &= t > float(EMBREE_CURVE_SELF_INTERSECTION_AVOIDANCE_FACTOR)*r*pre.depth_scale; // ignore self intersections
+
+          /* update hit information */
+          if (unlikely(any(valid))) {
+            DistanceCurveHit<NativeCurve3fa,W> hit(valid,u,0.0f,t,0,N,curve3D);
+            ishit = ishit | epilog(valid,hit);
+          }
+          i = W;
+        }
+#endif
+
+        if (unlikely(i < N))
         {
           /* process SIMD-size many segments per iteration */
-          for (int i=W; i<N; i+=W)
+          for (; i<N; i+=W)
           {
             /* evaluate the bezier curve */
             vboolx valid = vintx(i)+vintx(step) < vintx(N);

--- a/kernels/geometry/curve_intersector_sweep.h
+++ b/kernels/geometry/curve_intersector_sweep.h
@@ -82,10 +82,16 @@ namespace embree
         const Vec3fa dRdu = /*dQdu*/-dPdu;
         const Vec3fa dRdt = dQdt;//-dPdt;
 
-        const Vec3fa T = normalize(dPdu);
+        /* share a single rsqrt(dot(dPdu,dPdu)) between the normalize() and the
+           1/length(dPdu) needed for cos_err. Saves one transcendental per
+           Jacobian iteration (important on Xe iGPUs where sqrt/rsqrt are
+           ~14-20 cycle latency and there is no ILP to hide them). */
+        const float dPdu2 = dot(dPdu,dPdu);
+        const float rcp_len_dPdu = rsqrt(dPdu2);
+        const Vec3fa T = dPdu * rcp_len_dPdu;
         const Vec3fa dTdu = dnormalize(dPdu,ddPdu);
         //const Vec3fa dTdt = zero;
-        const float cos_err = P_err/length(dPdu);
+        const float cos_err = P_err * rcp_len_dPdu;
 
         /* Error estimate for dot(R,T):
 
@@ -348,8 +354,10 @@ namespace embree
         const Vec3ff dQ2 = abs(3.0f*(P3-P2) - W);
         const Vec3ff max_dQ = max(dQ0,dQ1,dQ2);
         const float m = max(max_dQ.x,max_dQ.y,max_dQ.z); //,max_dQ.w);
-        const float l = length(Vec3f(W));
-        const bool well_behaved = m < 0.2f*l;
+        /* compare squared values to avoid the sqrt in length(W); m is
+           non-negative since computed from abs() above, so this is exact. */
+        const float l2 = dot(Vec3f(W),Vec3f(W));
+        const bool well_behaved = m*m < (0.2f*0.2f)*l2;
 
         if (!well_behaved && stack.depth < max_depth) {
           stack.push();


### PR DESCRIPTION
Targets the SYCL/Xe code paths in the curve intersectors:

* curve_intersector_sweep.h (intersect_bezier_iterative_jacobian): share a single rsqrt(dot(dPdu,dPdu)) between the tangent normalization and the cos_err = P_err/length(dPdu) term, saving one sqrt/rsqrt per Jacobian iteration. Runs on both CPU and SYCL.

* curve_intersector_sweep.h (SYCL intersect_bezier_recursive_jacobian): replace the well-behaved test 'm < 0.2*length(W)' with the equivalent squared-form comparison 'm*m < 0.04*dot(W,W)', removing one sqrt per recursion step.

* curve_intersector_distance.h (DistanceCurve1Intersector1::intersect): the duplicated first-iteration prologue is now CPU-only (#if !defined(__SYCL_DEVICE_ONLY__)). On SYCL where W=1 the duplication only inflated kernel size; control flow now falls straight into the unified loop.
