### PR TITLE
Fix stale comment for triangle4n.

### DIFF
--- a/kernels/geometry/triangle.h
+++ b/kernels/geometry/triangle.h
@@ -8,8 +8,8 @@
 namespace embree
 {
   /* Precalculated representation for M triangles. Stores for each
-     triangle a base vertex, two edges, and the geometry normal to
-     speed up intersection calculations */
+     triangle a base vertex and two edges to speed up intersection 
+     calculations */
   template<int M>
   struct TriangleM
   {


### PR DESCRIPTION
It seems the normal field was removed for the `triangle4n` case [here](https://github.com/RenderKit/embree/commit/5f6ea260f0695eb5cd607eeff4a58cff21a26e97).