### PR TITLE
Excluded builders directory from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ kernels/hash.h
 include/embree4/rtcore_config.h
 build
 build*
+!builders
 out


### PR DESCRIPTION
The expression in `.gitignore` was too broad and told git to ignore some of our source code.